### PR TITLE
Remove the "debug" environment that tries to target an external server

### DIFF
--- a/IntegrationTestSuite/MessagePackIntegrationTests/MessagePackIntegrationTests.csproj
+++ b/IntegrationTestSuite/MessagePackIntegrationTests/MessagePackIntegrationTests.csproj
@@ -35,10 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Update="appsettings.Local.json">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-      <None Update="appsettings.Debug.json">
+      <None Update="appsettings.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
     </ItemGroup>

--- a/IntegrationTestSuite/MessagePackIntegrationTests/MessagePactTestsFixture.cs
+++ b/IntegrationTestSuite/MessagePackIntegrationTests/MessagePactTestsFixture.cs
@@ -50,24 +50,15 @@ namespace MessagePackIntegrationTests
         [SetUp]
         public void Setup()
         {
-            var appsettings = "";
-#if LOCAL
-            appsettings = "appsettings.Local.json";
-#endif
-
-#if DEBUG
-            appsettings = "appsettings.Debug.json";
-#endif
             this.configuration = new ConfigurationBuilder()
                 .SetBasePath(TestContext.CurrentContext.TestDirectory)
-                .AddJsonFile(appsettings)
+                .AddJsonFile("appsettings.json")
                 .Build();
             
             this.httpClient = this.CreateHttpClient(
                 this.configuration.GetSection("Username").Value,
                 this.configuration.GetSection("Password").Value,
                 this.configuration.GetSection("Hostname").Value);
-
         }
 
         private HttpClient CreateHttpClient(string username, string password, string url, bool withMessagePack = true)

--- a/IntegrationTestSuite/MessagePackIntegrationTests/appsettings.Debug.json
+++ b/IntegrationTestSuite/MessagePackIntegrationTests/appsettings.Debug.json
@@ -1,5 +1,0 @@
-﻿{
-  "Username": "admin",
-  "Password": "pass",
-  "Hostname": "https://cdp4services-test.cdp4.org/"
-}

--- a/IntegrationTestSuite/MessagePackIntegrationTests/appsettings.Local.json
+++ b/IntegrationTestSuite/MessagePackIntegrationTests/appsettings.Local.json
@@ -1,5 +1,0 @@
-﻿{
-  "Username": "admin",
-  "Password": "pass",
-  "Hostname": "http://localhost:5000"
-}

--- a/IntegrationTestSuite/MessagePackIntegrationTests/appsettings.json
+++ b/IntegrationTestSuite/MessagePackIntegrationTests/appsettings.json
@@ -1,0 +1,5 @@
+﻿{
+  "Username": "admin",
+  "Password": "pass",
+  "Hostname": "http://localhost:5000"
+}


### PR DESCRIPTION
This fix failure on the WebServices repository during CICD