### PR TITLE
Refactor equivalence assertions in integration tests

### DIFF
--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ActualFiniteStateList/ActualFiniteStateListTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ActualFiniteStateList/ActualFiniteStateListTestFixture.cs
@@ -317,9 +317,9 @@ namespace WebservicesIntegrationTests
             var possibleFiniteStateListsInActualFiniteStateList = JsonConvert.DeserializeObject<List<OrderedItem>>(
                 actualFiniteStateList[PropertyNames.PossibleFiniteStateList].ToString());
 
-            CollectionAssert.AreEquivalent(
-                expectedPossibleFiniteStateListsInActualFiniteStateList,
-                possibleFiniteStateListsInActualFiniteStateList);
+            Assert.That(
+                possibleFiniteStateListsInActualFiniteStateList,
+                Is.EquivalentTo(expectedPossibleFiniteStateListsInActualFiniteStateList));
 
             // get the created ActualState as a side effect of adding PossibleFiniteStateList from the result by it's unique id
             var actualStatesArray = (JArray) actualFiniteStateList[PropertyNames.ActualState];
@@ -394,9 +394,9 @@ namespace WebservicesIntegrationTests
             var reorderedPossibleFiniteStateListsInActualFiniteStateList = JsonConvert.DeserializeObject<List<OrderedItem>>(
                 actualFiniteStateList[PropertyNames.PossibleFiniteStateList].ToString());
 
-            CollectionAssert.AreEquivalent(
-                expectedReorderedPossibleFiniteStateListsInActualFiniteStateList,
-                reorderedPossibleFiniteStateListsInActualFiniteStateList);
+            Assert.That(
+                reorderedPossibleFiniteStateListsInActualFiniteStateList,
+                Is.EquivalentTo(expectedReorderedPossibleFiniteStateListsInActualFiniteStateList));
         }
 
         [Test]
@@ -432,7 +432,7 @@ namespace WebservicesIntegrationTests
                 JsonConvert.DeserializeObject<List<OrderedItem>>(
                     possibleFiniteStateList[PropertyNames.PossibleState].ToString());
 
-            CollectionAssert.AreEquivalent(expectedPossibleFiniteStates, possibleFiniteStates);
+            Assert.That(possibleFiniteStates, Is.EquivalentTo(expectedPossibleFiniteStates));
 
             var actualFiniteStateList = jArray.Single(
                 x => (string) x[PropertyNames.Iid] == "db690d7d-761c-47fd-96d3-840d698a89dc");
@@ -506,17 +506,17 @@ namespace WebservicesIntegrationTests
                 JsonConvert.DeserializeObject<List<OrderedItem>>(
                     actualFiniteStateList[PropertyNames.PossibleFiniteStateList].ToString());
 
-            CollectionAssert.AreEquivalent(expectedPossibleFiniteStateLists, possibleFiniteStateLists);
+            Assert.That(possibleFiniteStateLists, Is.EquivalentTo(expectedPossibleFiniteStateLists));
 
             var expectedActualStates = new[] { "b91bfdbb-4277-4a03-b519-e4db839ef5d4" };
             var actualStatesArray = (JArray) actualFiniteStateList[PropertyNames.ActualState];
             IList<string> actualStates = actualStatesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedActualStates, actualStates);
+            Assert.That(actualStates, Is.EquivalentTo(expectedActualStates));
 
             var expectedExcludedOptions = new string[] { };
             var excludedOptionsArray = (JArray) actualFiniteStateList[PropertyNames.ExcludeOption];
             IList<string> excludedOptions = excludedOptionsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedExcludedOptions, excludedOptions);
+            Assert.That(excludedOptions, Is.EquivalentTo(expectedExcludedOptions));
         }
 
         /// <summary>

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Note/NoteTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Note/NoteTestFixture.cs
@@ -114,9 +114,9 @@ namespace WebservicesIntegrationTests
                     new OrderedItem(2, "85ab7b55-6af5-48fb-a14a-86d16dfe1b57")
                 };
 
-            CollectionAssert.AreEquivalent(
-                expectedNoteList,
-                noteList);
+            Assert.That(
+                noteList,
+                Is.EquivalentTo(expectedNoteList));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Option/OptionTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Option/OptionTestFixture.cs
@@ -85,7 +85,7 @@ namespace WebservicesIntegrationTests
             Assert.That((int)iteration[PropertyNames.RevisionNumber], Is.EqualTo(3));
             var expectedOptions = new List<OrderedItem> { new OrderedItem(1, "bebcc9f4-ff20-4569-bbf6-d1acf27a8107"), new OrderedItem(2, "e90e4bcd-6e17-4b75-80fb-6cded78bed57") };
             var optionsArray = JsonConvert.DeserializeObject<List<OrderedItem>>(iteration[PropertyNames.Option].ToString());
-            CollectionAssert.AreEquivalent(expectedOptions, optionsArray);
+            Assert.That(optionsArray, Is.EquivalentTo(expectedOptions));
 
             var option = jArray.Single(x => (string)x[PropertyNames.Iid] == "e90e4bcd-6e17-4b75-80fb-6cded78bed57");
             Assert.That((int)option[PropertyNames.RevisionNumber], Is.EqualTo(3));

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Parameter/ParameterTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Parameter/ParameterTestFixture.cs
@@ -131,7 +131,7 @@ namespace WebservicesIntegrationTests
             var expectedParameterSubscriptions = new string[] { };
             var parameterSubscriptionsArray = (JArray) parameter[PropertyNames.ParameterSubscription];
             IList<string> parameterSubscriptions = parameterSubscriptionsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedParameterSubscriptions, parameterSubscriptions);
+            Assert.That(parameterSubscriptions, Is.EquivalentTo(expectedParameterSubscriptions));
 
             // get the created ParameterValueSet as a side effect of creating Parameter from the result by it's unique id
             var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
@@ -258,7 +258,7 @@ namespace WebservicesIntegrationTests
 
             var parametersArray = (JArray) elementDefinition[PropertyNames.Parameter];
             IList<string> parameters = parametersArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedParameters, parameters);
+            Assert.That(parameters, Is.EquivalentTo(expectedParameters));
 
             // get the added Parameter from the result by it's unique id
             var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "2cd4eb9c-e92c-41b2-968c-f03ff7010bad");

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Publication/PublicationTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Publication/PublicationTestFixture.cs
@@ -111,7 +111,7 @@ namespace WebservicesIntegrationTests
                                            };
             var publicationsArray = (JArray)iteration[PropertyNames.Publication];
             IList<string> publications = publicationsArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedPublications, publications);
+            Assert.That(publications, Is.EquivalentTo(expectedPublications));
 
             parameterValueSet = jArray.Single(x => (string)x[PropertyNames.Iid] == "72ec3701-bcb5-4bf6-bd78-30fd1b65e3be");
             Assert.AreEqual(3, (int)parameterValueSet[PropertyNames.RevisionNumber]);
@@ -130,7 +130,7 @@ namespace WebservicesIntegrationTests
                                       };
             var domainsArray = (JArray)publication[PropertyNames.Domain];
             IList<string> domains = domainsArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedDomains, domains);
+            Assert.That(domains, Is.EquivalentTo(expectedDomains));
 
             var expectedPublishedParameters = new string[]
                                                   {
@@ -138,7 +138,7 @@ namespace WebservicesIntegrationTests
                                                   };
             var publishedParametersArray = (JArray)publication[PropertyNames.PublishedParameter];
             IList<string> publishedParameters = publishedParametersArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedPublishedParameters, publishedParameters);
+            Assert.That(publishedParameters, Is.EquivalentTo(expectedPublishedParameters));
         }
 
         /// <summary>
@@ -163,12 +163,12 @@ namespace WebservicesIntegrationTests
             var expectedDomains = new string[] {};
             var domainsArray = (JArray) publication[PropertyNames.Domain];
             IList<string> domains = domainsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedDomains, domains);
+            Assert.That(domains, Is.EquivalentTo(expectedDomains));
 
             var expectedPublishedParameters = new string[] {};
             var publishedParametersArray = (JArray) publication[PropertyNames.PublishedParameter];
             IList<string> publishedParameters = publishedParametersArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedPublishedParameters, publishedParameters);
+            Assert.That(publishedParameters, Is.EquivalentTo(expectedPublishedParameters));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/BinaryRelationshipRule/BinaryRelationshipRuleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/BinaryRelationshipRule/BinaryRelationshipRuleTestFixture.cs
@@ -106,17 +106,17 @@ namespace WebservicesIntegrationTests
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) binaryRelationshipRule["alias"];
             IList<string> aliases = aliasesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedAliases, aliases);
+            Assert.That(aliases, Is.EquivalentTo(expectedAliases));
 
             var expectedDefinitions = new string[] {};
             var definitionsArray = (JArray) binaryRelationshipRule["definition"];
             IList<string> definitions = definitionsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedDefinitions, definitions);
+            Assert.That(definitions, Is.EquivalentTo(expectedDefinitions));
 
             var expectedHyperlinks = new string[] {};
             var hyperlinksArray = (JArray) binaryRelationshipRule["hyperLink"];
             IList<string> h = hyperlinksArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedHyperlinks, h);
+            Assert.That(h, Is.EquivalentTo(expectedHyperlinks));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/EnumerationParameterType/EnumerationParameterTypeTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/EnumerationParameterType/EnumerationParameterTypeTestFixture.cs
@@ -303,7 +303,7 @@ namespace WebservicesIntegrationTests
 
             var referenceSourcesArray = (JArray) siteReferenceDataLibrary[PropertyNames.ReferenceSource];
             IList<string> referenceSourcesList = referenceSourcesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedReferenceSources, referenceSourcesList);
+            Assert.That(referenceSourcesList, Is.EquivalentTo(expectedReferenceSources));
 
             var expectedRules = new string[]
             {
@@ -316,7 +316,7 @@ namespace WebservicesIntegrationTests
 
             var rulesArray = (JArray) siteReferenceDataLibrary[PropertyNames.Rule];
             IList<string> rulesList = rulesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedRules, rulesList);
+            Assert.That(rulesList, Is.EquivalentTo(expectedRules));
 
             Assert.IsEmpty(siteReferenceDataLibrary["requiredRdl"]);
 
@@ -327,7 +327,7 @@ namespace WebservicesIntegrationTests
 
             var constantsArray = (JArray) siteReferenceDataLibrary[PropertyNames.Constant];
             IList<string> constantsList = constantsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedConstants, constantsList);
+            Assert.That(constantsList, Is.EquivalentTo(expectedConstants));
 
             //
             var enumerationParameterType =
@@ -355,29 +355,29 @@ namespace WebservicesIntegrationTests
             var valueDefinitionsArray = JsonConvert.DeserializeObject<List<OrderedItem>>(
                 enumerationParameterType["valueDefinition"].ToString());
 
-            CollectionAssert.AreEquivalent(expectedValueDefinitions, valueDefinitionsArray);
+            Assert.That(valueDefinitionsArray, Is.EquivalentTo(expectedValueDefinitions));
 
             Assert.That((string)enumerationParameterType["symbol"], Is.EqualTo("enumerationparametertype"));
 
             var expectedCategories = new string[] { };
             var categoriesArray = (JArray) enumerationParameterType["category"];
             IList<string> categories = categoriesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedCategories, categories);
+            Assert.That(categories, Is.EquivalentTo(expectedCategories));
 
             var expectedEnumAliases = new string[] { };
             var enumAliasesArray = (JArray) enumerationParameterType["alias"];
             IList<string> enumAliases = enumAliasesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedEnumAliases, enumAliases);
+            Assert.That(enumAliases, Is.EquivalentTo(expectedEnumAliases));
 
             var expectedEnumDefinitions = new string[] { };
             var enumDefinitionsArray = (JArray) enumerationParameterType["definition"];
             IList<string> enumDefinitions = enumDefinitionsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedEnumDefinitions, enumDefinitions);
+            Assert.That(enumDefinitions, Is.EquivalentTo(expectedEnumDefinitions));
 
             var expectedEnumHyperlinks = new string[] { };
             var enumHyperlinksArray = (JArray) enumerationParameterType["hyperLink"];
             IList<string> hyperLinks = enumHyperlinksArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedEnumHyperlinks, hyperLinks);
+            Assert.That(hyperLinks, Is.EquivalentTo(expectedEnumHyperlinks));
 
             //Add New EnumerationParamerterDefinition
             postBodyPath = this.GetPath("Tests/SiteDirectory/EnumerationParameterType/PostAddNewEnumerationValueDefinition.json");
@@ -400,7 +400,7 @@ namespace WebservicesIntegrationTests
             valueDefinitionsArray = JsonConvert.DeserializeObject<List<OrderedItem>>(
                 enumerationParameterType["valueDefinition"].ToString());
 
-            CollectionAssert.AreEquivalent(expectedValueDefinitions, valueDefinitionsArray);
+            Assert.That(valueDefinitionsArray, Is.EquivalentTo(expectedValueDefinitions));
 
             //Reorder EnumerationValueDefinitions
             postBodyPath = this.GetPath("Tests/SiteDirectory/EnumerationParameterType/PostReorderEnumerationValueDefinition.json");
@@ -422,7 +422,7 @@ namespace WebservicesIntegrationTests
             valueDefinitionsArray = JsonConvert.DeserializeObject<List<OrderedItem>>(
                 enumerationParameterType["valueDefinition"].ToString());
 
-            CollectionAssert.AreEquivalent(expectedValueDefinitions, valueDefinitionsArray);
+            Assert.That(valueDefinitionsArray, Is.EquivalentTo(expectedValueDefinitions));
 
             //delete EnumerationValueDefinition
             postBodyPath = this.GetPath("Tests/SiteDirectory/EnumerationParameterType/PostDeleteEnumerationValueDefinition.json");
@@ -443,7 +443,7 @@ namespace WebservicesIntegrationTests
             valueDefinitionsArray = JsonConvert.DeserializeObject<List<OrderedItem>>(
                 enumerationParameterType["valueDefinition"].ToString());
 
-            CollectionAssert.AreEquivalent(expectedValueDefinitions, valueDefinitionsArray);
+            Assert.That(valueDefinitionsArray, Is.EquivalentTo(expectedValueDefinitions));
         }
 
         /// <summary>
@@ -478,29 +478,29 @@ namespace WebservicesIntegrationTests
             var valueDefinitionsArray = JsonConvert.DeserializeObject<List<OrderedItem>>(
                 enumerationParameterType["valueDefinition"].ToString());
 
-            CollectionAssert.AreEquivalent(expectedValueDefinitions, valueDefinitionsArray);
+            Assert.That(valueDefinitionsArray, Is.EquivalentTo(expectedValueDefinitions));
 
             Assert.That((string)enumerationParameterType["symbol"], Is.EqualTo("enumerationparametertype"));
 
             var expectedCategories = new string[] { };
             var categoriesArray = (JArray) enumerationParameterType["category"];
             IList<string> categories = categoriesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedCategories, categories);
+            Assert.That(categories, Is.EquivalentTo(expectedCategories));
 
             var expectedAliases = new string[] { };
             var aliasesArray = (JArray) enumerationParameterType["alias"];
             IList<string> aliases = aliasesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedAliases, aliases);
+            Assert.That(aliases, Is.EquivalentTo(expectedAliases));
 
             var expectedDefinitions = new string[] { };
             var definitionsArray = (JArray) enumerationParameterType["definition"];
             IList<string> definitions = definitionsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedDefinitions, definitions);
+            Assert.That(definitions, Is.EquivalentTo(expectedDefinitions));
 
             var expectedHyperlinks = new string[] { };
             var hyperlinksArray = (JArray) enumerationParameterType["hyperLink"];
             IList<string> h = hyperlinksArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedHyperlinks, h);
+            Assert.That(h, Is.EquivalentTo(expectedHyperlinks));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/PrefixedUnit/PrefixedUnitTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/PrefixedUnit/PrefixedUnitTestFixture.cs
@@ -103,32 +103,32 @@ namespace WebservicesIntegrationTests
             var expectedOrganizations = new string[] { "cd22fc45-d898-4fac-85fc-fbcb7d7b12a7" };
             var organizationArray = (JArray)siteDirectory[PropertyNames.Organization];
             IList<string> organizations = organizationArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedOrganizations, organizations);
+            Assert.That(organizations, Is.EquivalentTo(expectedOrganizations));
 
             var expectedPersons = new string[] { "77791b12-4c2c-4499-93fa-869df3692d22" };
             var personArray = (JArray)siteDirectory[PropertyNames.Person];
             IList<string> persons = personArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedPersons, persons);
+            Assert.That(persons, Is.EquivalentTo(expectedPersons));
 
             var expectedparticipantRole = new string[] { "ee3ae5ff-ac5e-4957-bab1-7698fba2a267" };
             var participantRoleArray = (JArray)siteDirectory[PropertyNames.ParticipantRole];
             IList<string> participantRoles = participantRoleArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedparticipantRole, participantRoles);
+            Assert.That(participantRoles, Is.EquivalentTo(expectedparticipantRole));
 
             var expectedsiteReferenceDataLibraries = new string[] { "c454c687-ba3e-44c4-86bc-44544b2c7880" };
             var siteReferenceDataLibraryArray = (JArray)siteDirectory[PropertyNames.SiteReferenceDataLibrary];
             IList<string> siteReferenceDataLibraries = siteReferenceDataLibraryArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedsiteReferenceDataLibraries, siteReferenceDataLibraries);
+            Assert.That(siteReferenceDataLibraries, Is.EquivalentTo(expectedsiteReferenceDataLibraries));
 
             var expectedModels = new string[] { "116f6253-89bb-47d4-aa24-d11d197e43c9" };
             var modelArray = (JArray)siteDirectory[PropertyNames.Model];
             IList<string> models = modelArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedModels, models);
+            Assert.That(models, Is.EquivalentTo(expectedModels));
 
             var expectedPersonRoles = new string[] { "2428f4d9-f26d-4112-9d56-1c940748df69" };
             var personRoleArray = (JArray)siteDirectory[PropertyNames.PersonRole];
             IList<string> personRoles = personRoleArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedPersonRoles, personRoles);
+            Assert.That(personRoles, Is.EquivalentTo(expectedPersonRoles));
 
             var expectedlogEntries = new string[]
             {
@@ -137,12 +137,12 @@ namespace WebservicesIntegrationTests
             };
             var logEntryArray = (JArray)siteDirectory[PropertyNames.LogEntry];
             IList<string> logEntries = logEntryArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedlogEntries, logEntries);
+            Assert.That(logEntries, Is.EquivalentTo(expectedlogEntries));
 
             var expecteddomainGroups = new string[] { "86992db5-8ce2-4431-8ff5-6fe794d14687" };
             var domainGroupArray = (JArray)siteDirectory[PropertyNames.DomainGroup];
             IList<string> domainGroups = domainGroupArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expecteddomainGroups, domainGroups);
+            Assert.That(domainGroups, Is.EquivalentTo(expecteddomainGroups));
 
             var expectedDomains = new string[]
             {
@@ -151,12 +151,12 @@ namespace WebservicesIntegrationTests
             };
             var domainArray = (JArray)siteDirectory[PropertyNames.Domain];
             IList<string> domains = domainArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedDomains, domains);
+            Assert.That(domains, Is.EquivalentTo(expectedDomains));
 
             var expectedNaturalLanguages = new string[] { "73bf30cc-3573-488f-8746-6c03ba47973e" };
             var naturalLanguageArray = (JArray)siteDirectory[PropertyNames.NaturalLanguage];
             IList<string> naturalLanguages = naturalLanguageArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedNaturalLanguages, naturalLanguages);
+            Assert.That(naturalLanguages, Is.EquivalentTo(expectedNaturalLanguages));
 
             // SiteReferenceDataLibrary
             var siteReferenceDataLibrary = jArray.Single(x => (string)x[PropertyNames.Iid] == "c454c687-ba3e-44c4-86bc-44544b2c7880");
@@ -176,17 +176,17 @@ namespace WebservicesIntegrationTests
             var expectedAliases = new string[] { };
             var aliasesArray = (JArray)siteReferenceDataLibrary[PropertyNames.Alias];
             IList<string> aliases = aliasesArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedAliases, aliases);
+            Assert.That(aliases, Is.EquivalentTo(expectedAliases));
 
             var expectedDefinitions = new string[] { };
             var definitionsArray = (JArray)siteReferenceDataLibrary[PropertyNames.Definition];
             IList<string> definitions = definitionsArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedDefinitions, definitions);
+            Assert.That(definitions, Is.EquivalentTo(expectedDefinitions));
 
             var expectedHyperlinks = new string[] { };
             var hyperlinksArray = (JArray)siteReferenceDataLibrary[PropertyNames.HyperLink];
             IList<string> h = hyperlinksArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedHyperlinks, h);
+            Assert.That(h, Is.EquivalentTo(expectedHyperlinks));
 
             var expectedDefinedCategories = new string[]
             {
@@ -196,7 +196,7 @@ namespace WebservicesIntegrationTests
             };
             var definedCategoriesArray = (JArray)siteReferenceDataLibrary[PropertyNames.DefinedCategory];
             IList<string> definedCategoriesList = definedCategoriesArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedDefinedCategories, definedCategoriesList);
+            Assert.That(definedCategoriesList, Is.EquivalentTo(expectedDefinedCategories));
 
             var expectedParameterTypes = new string[]
             {
@@ -214,7 +214,7 @@ namespace WebservicesIntegrationTests
             };
             var parameterTypesArray = (JArray)siteReferenceDataLibrary[PropertyNames.ParameterType];
             IList<string> parameterTypesList = parameterTypesArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedParameterTypes, parameterTypesList);
+            Assert.That(parameterTypesList, Is.EquivalentTo(expectedParameterTypes));
 
             var expectedBaseQuantityKinds = new List<OrderedItem>
             {
@@ -222,7 +222,7 @@ namespace WebservicesIntegrationTests
             };
             var baseQuantityKindsArray = JsonConvert.DeserializeObject<List<OrderedItem>>(
                 siteReferenceDataLibrary[PropertyNames.BaseQuantityKind].ToString());
-            CollectionAssert.AreEquivalent(expectedBaseQuantityKinds, baseQuantityKindsArray);
+            Assert.That(baseQuantityKindsArray, Is.EquivalentTo(expectedBaseQuantityKinds));
 
             var expectedScales = new string[]
             {
@@ -234,7 +234,7 @@ namespace WebservicesIntegrationTests
             };
             var scalesArray = (JArray)siteReferenceDataLibrary[PropertyNames.Scale];
             IList<string> scalesList = scalesArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedScales, scalesList);
+            Assert.That(scalesList, Is.EquivalentTo(expectedScales));
 
             var expectedUnitPrefixes = new string[]
             {
@@ -242,7 +242,7 @@ namespace WebservicesIntegrationTests
             };
             var unitPrefixesArray = (JArray)siteReferenceDataLibrary[PropertyNames.UnitPrefix];
             IList<string> unitPrefixesList = unitPrefixesArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedUnitPrefixes, unitPrefixesList);
+            Assert.That(unitPrefixesList, Is.EquivalentTo(expectedUnitPrefixes));
 
             var expectedUnits = new string[]
             {
@@ -254,7 +254,7 @@ namespace WebservicesIntegrationTests
             };
             var unitsArray = (JArray)siteReferenceDataLibrary[PropertyNames.Unit];
             IList<string> unitsList = unitsArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedUnits, unitsList);
+            Assert.That(unitsList, Is.EquivalentTo(expectedUnits));
 
             var expectedBaseUnits = new string[]
             {
@@ -262,7 +262,7 @@ namespace WebservicesIntegrationTests
             };
             var baseUnitsArray = (JArray)siteReferenceDataLibrary[PropertyNames.BaseUnit];
             IList<string> baseUnitsList = baseUnitsArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedBaseUnits, baseUnitsList);
+            Assert.That(baseUnitsList, Is.EquivalentTo(expectedBaseUnits));
 
             var expectedFileTypes = new string[]
             {
@@ -272,7 +272,7 @@ namespace WebservicesIntegrationTests
             };
             var fileTypesArray = (JArray)siteReferenceDataLibrary[PropertyNames.FileType];
             IList<string> fileTypesList = fileTypesArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedFileTypes, fileTypesList);
+            Assert.That(fileTypesList, Is.EquivalentTo(expectedFileTypes));
 
             var expectedGlossaries = new string[]
             {
@@ -280,7 +280,7 @@ namespace WebservicesIntegrationTests
             };
             var glossariesArray = (JArray)siteReferenceDataLibrary[PropertyNames.Glossary];
             IList<string> glossariesList = glossariesArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedGlossaries, glossariesList);
+            Assert.That(glossariesList, Is.EquivalentTo(expectedGlossaries));
 
             var expectedReferenceSources = new string[]
             {
@@ -288,7 +288,7 @@ namespace WebservicesIntegrationTests
             };
             var referenceSourcesArray = (JArray)siteReferenceDataLibrary[PropertyNames.ReferenceSource];
             IList<string> referenceSourcesList = referenceSourcesArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedReferenceSources, referenceSourcesList);
+            Assert.That(referenceSourcesList, Is.EquivalentTo(expectedReferenceSources));
 
             var expectedRules = new string[]
             {
@@ -300,7 +300,7 @@ namespace WebservicesIntegrationTests
             };
             var rulesArray = (JArray)siteReferenceDataLibrary[PropertyNames.Rule];
             IList<string> rulesList = rulesArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedRules, rulesList);
+            Assert.That(rulesList, Is.EquivalentTo(expectedRules));
 
             Assert.IsEmpty(siteReferenceDataLibrary["requiredRdl"]);
 
@@ -310,7 +310,7 @@ namespace WebservicesIntegrationTests
             };
             var constantsArray = (JArray)siteReferenceDataLibrary[PropertyNames.Constant];
             IList<string> constantsList = constantsArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedConstants, constantsList);
+            Assert.That(constantsList, Is.EquivalentTo(expectedConstants));
 
             // PrefixedUnit
             var prefixedUnit = jArray.Single(x => (string)x[PropertyNames.Iid] == "9fb8085f-a7d3-4068-95e3-686e4d954d1c");
@@ -330,17 +330,17 @@ namespace WebservicesIntegrationTests
             var expectedPrefixedUnitAliases = new string[] { };
             var prefixedUnitAliasesArray = (JArray)prefixedUnit[PropertyNames.Alias];
             IList<string> prefixedUnitAliases = prefixedUnitAliasesArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedPrefixedUnitAliases, prefixedUnitAliases);
+            Assert.That(prefixedUnitAliases, Is.EquivalentTo(expectedPrefixedUnitAliases));
 
             var expectedPrefixedUnitDefinitions = new string[] { };
             var prefixedUnitDefinitionsArray = (JArray)prefixedUnit[PropertyNames.Definition];
             IList<string> prefixedUnitDefinitions = prefixedUnitDefinitionsArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedPrefixedUnitDefinitions, prefixedUnitDefinitions);
+            Assert.That(prefixedUnitDefinitions, Is.EquivalentTo(expectedPrefixedUnitDefinitions));
 
             var expectedPrefixedUnitHyperlinks = new string[] { };
             var prefixedUnitHyperlinksArray = (JArray)prefixedUnit[PropertyNames.HyperLink];
             IList<string> hyperLinks = prefixedUnitHyperlinksArray.Select(x => (string)x).ToList();
-            CollectionAssert.AreEquivalent(expectedPrefixedUnitHyperlinks, hyperLinks);
+            Assert.That(hyperLinks, Is.EquivalentTo(expectedPrefixedUnitHyperlinks));
         }
 
         /// <summary>
@@ -367,17 +367,17 @@ namespace WebservicesIntegrationTests
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) prefixedUnit["alias"];
             IList<string> aliases = aliasesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedAliases, aliases);
+            Assert.That(aliases, Is.EquivalentTo(expectedAliases));
 
             var expectedDefinitions = new string[] {};
             var definitionsArray = (JArray) prefixedUnit["definition"];
             IList<string> definitions = definitionsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedDefinitions, definitions);
+            Assert.That(definitions, Is.EquivalentTo(expectedDefinitions));
 
             var expectedHyperlinks = new string[] {};
             var hyperlinksArray = (JArray) prefixedUnit["hyperLink"];
             IList<string> h = hyperlinksArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedHyperlinks, h);
+            Assert.That(h, Is.EquivalentTo(expectedHyperlinks));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SiteReferenceDataLibrary/SiteReferenceDataLibraryTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SiteReferenceDataLibrary/SiteReferenceDataLibraryTestFixture.cs
@@ -183,7 +183,7 @@ namespace WebservicesIntegrationTests
             };
             var parameterTypesArray = (JArray) siteReferenceDataLibrary["parameterType"];
             IList<string> parameterTypesList = parameterTypesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedParameterTypes, parameterTypesList);
+            Assert.That(parameterTypesList, Is.EquivalentTo(expectedParameterTypes));
 
             var expectedBaseQuantityKinds = new List<OrderedItem>
             {
@@ -191,7 +191,7 @@ namespace WebservicesIntegrationTests
             };
             var baseQuantityKindsArray = JsonConvert.DeserializeObject<List<OrderedItem>>(
                 siteReferenceDataLibrary["baseQuantityKind"].ToString());
-            CollectionAssert.AreEquivalent(expectedBaseQuantityKinds, baseQuantityKindsArray);
+            Assert.That(baseQuantityKindsArray, Is.EquivalentTo(expectedBaseQuantityKinds));
 
             var expectedScales = new string[]
             {
@@ -203,7 +203,7 @@ namespace WebservicesIntegrationTests
             };
             var scalesArray = (JArray) siteReferenceDataLibrary["scale"];
             IList<string> scalesList = scalesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedScales, scalesList);
+            Assert.That(scalesList, Is.EquivalentTo(expectedScales));
 
             var expectedUnitPrefixes = new string[]
             {
@@ -211,7 +211,7 @@ namespace WebservicesIntegrationTests
             };
             var unitPrefixesArray = (JArray) siteReferenceDataLibrary["unitPrefix"];
             IList<string> unitPrefixesList = unitPrefixesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedUnitPrefixes, unitPrefixesList);
+            Assert.That(unitPrefixesList, Is.EquivalentTo(expectedUnitPrefixes));
 
             var expectedUnits = new string[]
             {
@@ -222,7 +222,7 @@ namespace WebservicesIntegrationTests
             };
             var unitsArray = (JArray) siteReferenceDataLibrary["unit"];
             IList<string> unitsList = unitsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedUnits, unitsList);
+            Assert.That(unitsList, Is.EquivalentTo(expectedUnits));
 
             var expectedBaseUnits = new string[]
             {
@@ -230,7 +230,7 @@ namespace WebservicesIntegrationTests
             };
             var baseUnitsArray = (JArray) siteReferenceDataLibrary["baseUnit"];
             IList<string> baseUnitsList = baseUnitsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedBaseUnits, baseUnitsList);
+            Assert.That(baseUnitsList, Is.EquivalentTo(expectedBaseUnits));
 
             var expectedFileTypes = new string[]
             {
@@ -240,7 +240,7 @@ namespace WebservicesIntegrationTests
             };
             var fileTypesArray = (JArray) siteReferenceDataLibrary["fileType"];
             IList<string> fileTypesList = fileTypesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedFileTypes, fileTypesList);
+            Assert.That(fileTypesList, Is.EquivalentTo(expectedFileTypes));
 
             var expectedGlossaries = new string[]
             {
@@ -248,7 +248,7 @@ namespace WebservicesIntegrationTests
             };
             var glossariesArray = (JArray) siteReferenceDataLibrary["glossary"];
             IList<string> glossariesList = glossariesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedGlossaries, glossariesList);
+            Assert.That(glossariesList, Is.EquivalentTo(expectedGlossaries));
 
             var expectedReferenceSources = new string[]
             {
@@ -256,7 +256,7 @@ namespace WebservicesIntegrationTests
             };
             var referenceSourcesArray = (JArray) siteReferenceDataLibrary["referenceSource"];
             IList<string> referenceSourcesList = referenceSourcesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedReferenceSources, referenceSourcesList);
+            Assert.That(referenceSourcesList, Is.EquivalentTo(expectedReferenceSources));
 
             var expectedRules = new string[]
             {
@@ -268,7 +268,7 @@ namespace WebservicesIntegrationTests
             };
             var rulesArray = (JArray) siteReferenceDataLibrary["rule"];
             IList<string> rulesList = rulesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedRules, rulesList);
+            Assert.That(rulesList, Is.EquivalentTo(expectedRules));
 
             Assert.IsEmpty(siteReferenceDataLibrary["requiredRdl"]);
 
@@ -278,7 +278,7 @@ namespace WebservicesIntegrationTests
             };
             var constantsArray = (JArray) siteReferenceDataLibrary["constant"];
             IList<string> constantsList = constantsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedConstants, constantsList);
+            Assert.That(constantsList, Is.EquivalentTo(expectedConstants));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SpecializedQuantityKind/SpecializedQuantityKindTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SpecializedQuantityKind/SpecializedQuantityKindTestFixture.cs
@@ -109,27 +109,27 @@ namespace WebservicesIntegrationTests
             };
             var possibleScalesArray = (JArray) specializedQuantityKind[PropertyNames.PossibleScale];
             IList<string> possibleScales = possibleScalesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedPossibleScales, possibleScales);
+            Assert.That(possibleScales, Is.EquivalentTo(expectedPossibleScales));
 
             var expectedCategories = new string[] {};
             var categoriesArray = (JArray) specializedQuantityKind[PropertyNames.Category];
             IList<string> categories = categoriesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedCategories, categories);
+            Assert.That(categories, Is.EquivalentTo(expectedCategories));
 
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) specializedQuantityKind[PropertyNames.Alias];
             IList<string> aliases = aliasesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedAliases, aliases);
+            Assert.That(aliases, Is.EquivalentTo(expectedAliases));
 
             var expectedDefinitions = new string[] {};
             var definitionsArray = (JArray) specializedQuantityKind[PropertyNames.Definition];
             IList<string> definitions = definitionsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedDefinitions, definitions);
+            Assert.That(definitions, Is.EquivalentTo(expectedDefinitions));
 
             var expectedHyperlinks = new string[] {};
             var hyperlinksArray = (JArray) specializedQuantityKind[PropertyNames.HyperLink];
             IList<string> h = hyperlinksArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedHyperlinks, h);
+            Assert.That(h, Is.EquivalentTo(expectedHyperlinks));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TelephoneNumber/TelephoneNumberTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TelephoneNumber/TelephoneNumberTestFixture.cs
@@ -92,7 +92,7 @@ namespace WebservicesIntegrationTests
 
             var vcardTypesArray = (JArray) telephoneNumber[PropertyNames.VcardType];
             IList<string> vcardTypes = vcardTypesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedVcardTypes, vcardTypes);
+            Assert.That(vcardTypes, Is.EquivalentTo(expectedVcardTypes));
 
             postBodyPath = this.GetPath("Tests/SiteDirectory/TelephoneNumber/PostDeleteTelephoneNumberVcardType.json");
             postBody = this.GetJsonFromFile(postBodyPath);
@@ -104,7 +104,7 @@ namespace WebservicesIntegrationTests
 
             vcardTypesArray = (JArray) telephoneNumber[PropertyNames.VcardType];
             vcardTypes = vcardTypesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedVcardTypes, vcardTypes);
+            Assert.That(vcardTypes, Is.EquivalentTo(expectedVcardTypes));
         }
 
         [Test]
@@ -137,34 +137,34 @@ namespace WebservicesIntegrationTests
             var expectedOrganizations = new string[] { "cd22fc45-d898-4fac-85fc-fbcb7d7b12a7" };
             var organizationArray = (JArray) siteDirectory[PropertyNames.Organization];
             IList<string> organizations = organizationArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedOrganizations, organizations);
+            Assert.That(organizations, Is.EquivalentTo(expectedOrganizations));
 
             var expectedPersons = new string[]
                 { "77791b12-4c2c-4499-93fa-869df3692d22" };
 
             var personArray = (JArray) siteDirectory[PropertyNames.Person];
             IList<string> persons = personArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedPersons, persons);
+            Assert.That(persons, Is.EquivalentTo(expectedPersons));
 
             var expectedparticipantRole = new string[] { "ee3ae5ff-ac5e-4957-bab1-7698fba2a267" };
             var participantRoleArray = (JArray) siteDirectory[PropertyNames.ParticipantRole];
             IList<string> participantRoles = participantRoleArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedparticipantRole, participantRoles);
+            Assert.That(participantRoles, Is.EquivalentTo(expectedparticipantRole));
 
             var expectedsiteReferenceDataLibraries = new string[] { "c454c687-ba3e-44c4-86bc-44544b2c7880" };
             var siteReferenceDataLibraryArray = (JArray) siteDirectory[PropertyNames.SiteReferenceDataLibrary];
             IList<string> siteReferenceDataLibraries = siteReferenceDataLibraryArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedsiteReferenceDataLibraries, siteReferenceDataLibraries);
+            Assert.That(siteReferenceDataLibraries, Is.EquivalentTo(expectedsiteReferenceDataLibraries));
 
             var expectedModels = new string[] { "116f6253-89bb-47d4-aa24-d11d197e43c9" };
             var modelArray = (JArray) siteDirectory[PropertyNames.Model];
             IList<string> models = modelArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedModels, models);
+            Assert.That(models, Is.EquivalentTo(expectedModels));
 
             var expectedPersonRoles = new string[] { "2428f4d9-f26d-4112-9d56-1c940748df69" };
             var personRoleArray = (JArray) siteDirectory[PropertyNames.PersonRole];
             IList<string> personRoles = personRoleArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedPersonRoles, personRoles);
+            Assert.That(personRoles, Is.EquivalentTo(expectedPersonRoles));
 
             var expectedlogEntries = new string[]
             {
@@ -174,12 +174,12 @@ namespace WebservicesIntegrationTests
 
             var logEntryArray = (JArray) siteDirectory[PropertyNames.LogEntry];
             IList<string> logEntries = logEntryArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedlogEntries, logEntries);
+            Assert.That(logEntries, Is.EquivalentTo(expectedlogEntries));
 
             var expecteddomainGroups = new string[] { "86992db5-8ce2-4431-8ff5-6fe794d14687" };
             var domainGroupArray = (JArray) siteDirectory[PropertyNames.DomainGroup];
             IList<string> domainGroups = domainGroupArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expecteddomainGroups, domainGroups);
+            Assert.That(domainGroups, Is.EquivalentTo(expecteddomainGroups));
 
             var expectedDomains = new string[]
             {
@@ -189,12 +189,12 @@ namespace WebservicesIntegrationTests
 
             var domainArray = (JArray) siteDirectory[PropertyNames.Domain];
             IList<string> domains = domainArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedDomains, domains);
+            Assert.That(domains, Is.EquivalentTo(expectedDomains));
 
             var expectedNaturalLanguages = new string[] { "73bf30cc-3573-488f-8746-6c03ba47973e" };
             var naturalLanguageArray = (JArray) siteDirectory[PropertyNames.NaturalLanguage];
             IList<string> naturalLanguages = naturalLanguageArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedNaturalLanguages, naturalLanguages);
+            Assert.That(naturalLanguages, Is.EquivalentTo(expectedNaturalLanguages));
 
             // get a specific Person from the result by it's unique id
             var person =
@@ -228,7 +228,7 @@ namespace WebservicesIntegrationTests
 
             var emailAddresses = (JArray) person[PropertyNames.EmailAddress];
             IList<string> e = emailAddresses.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedEmailAddresses, e);
+            Assert.That(e, Is.EquivalentTo(expectedEmailAddresses));
 
             // verify that there are 2 telephoneNumbers for this person
             var expectedTelephoneNumbers = new string[]
@@ -240,7 +240,7 @@ namespace WebservicesIntegrationTests
 
             var telephoneNumbers = (JArray) person[PropertyNames.TelephoneNumber];
             IList<string> t = telephoneNumbers.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedTelephoneNumbers, t);
+            Assert.That(t, Is.EquivalentTo(expectedTelephoneNumbers));
 
             // verify that there are no userPreference for this person
             var userPreferences = (JArray) person[PropertyNames.UserPreference];
@@ -264,7 +264,7 @@ namespace WebservicesIntegrationTests
 
             var vcardTypesArray = (JArray) telephoneNumber[PropertyNames.VcardType];
             IList<string> vcardTypes = vcardTypesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedVcardTypes, vcardTypes);
+            Assert.That(vcardTypes, Is.EquivalentTo(expectedVcardTypes));
         }
 
         /// <summary>
@@ -290,7 +290,7 @@ namespace WebservicesIntegrationTests
 
             var vcardTypesArray = (JArray) telephoneNumberObject[PropertyNames.VcardType];
             IList<string> vcardTypes = vcardTypesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedVcardTypes, vcardTypes);
+            Assert.That(vcardTypes, Is.EquivalentTo(expectedVcardTypes));
 
             telephoneNumberObject =
                 telephoneNumber.Single(x => (string) x[PropertyNames.Iid] == "0367167c-80cb-4f99-a24b-e713efd15436");
@@ -308,7 +308,7 @@ namespace WebservicesIntegrationTests
 
             vcardTypesArray = (JArray) telephoneNumberObject[PropertyNames.VcardType];
             vcardTypes = vcardTypesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedVcardTypes, vcardTypes);
+            Assert.That(vcardTypes, Is.EquivalentTo(expectedVcardTypes));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Term/TermTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Term/TermTestFixture.cs
@@ -100,17 +100,17 @@ namespace WebservicesIntegrationTests
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) term["alias"];
             IList<string> aliases = aliasesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedAliases, aliases);
+            Assert.That(aliases, Is.EquivalentTo(expectedAliases));
 
             var expectedDefinitions = new string[] {};
             var definitionsArray = (JArray) term["definition"];
             IList<string> definitions = definitionsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedDefinitions, definitions);
+            Assert.That(definitions, Is.EquivalentTo(expectedDefinitions));
 
             var expectedHyperlinks = new string[] {};
             var hyperlinksArray = (JArray) term["hyperLink"];
             IList<string> h = hyperlinksArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedHyperlinks, h);
+            Assert.That(h, Is.EquivalentTo(expectedHyperlinks));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TextParameterType/TextParameterTypeTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TextParameterType/TextParameterTypeTestFixture.cs
@@ -98,22 +98,22 @@ namespace WebservicesIntegrationTests
             var expectedCategories = new string[] {};
             var categoriesArray = (JArray) textParameterType[PropertyNames.Category];
             IList<string> categories = categoriesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedCategories, categories);
+            Assert.That(categories, Is.EquivalentTo(expectedCategories));
 
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) textParameterType[PropertyNames.Alias];
             IList<string> aliases = aliasesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedAliases, aliases);
+            Assert.That(aliases, Is.EquivalentTo(expectedAliases));
 
             var expectedDefinitions = new string[] {};
             var definitionsArray = (JArray) textParameterType[PropertyNames.Definition];
             IList<string> definitions = definitionsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedDefinitions, definitions);
+            Assert.That(definitions, Is.EquivalentTo(expectedDefinitions));
 
             var expectedHyperlinks = new string[] {};
             var hyperlinksArray = (JArray) textParameterType[PropertyNames.HyperLink];
             IList<string> h = hyperlinksArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedHyperlinks, h);
+            Assert.That(h, Is.EquivalentTo(expectedHyperlinks));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TimeOfDayParameterType/TimeOfDayParameterTypeTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TimeOfDayParameterType/TimeOfDayParameterTypeTestFixture.cs
@@ -102,22 +102,22 @@ namespace WebservicesIntegrationTests
             var expectedCategories = new string[] {};
             var categoriesArray = (JArray) timeOfDayParameterType[PropertyNames.Category];
             IList<string> categories = categoriesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedCategories, categories);
+            Assert.That(categories, Is.EquivalentTo(expectedCategories));
 
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) timeOfDayParameterType[PropertyNames.Alias];
             IList<string> aliases = aliasesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedAliases, aliases);
+            Assert.That(aliases, Is.EquivalentTo(expectedAliases));
 
             var expectedDefinitions = new string[] {};
             var definitionsArray = (JArray) timeOfDayParameterType[PropertyNames.Definition];
             IList<string> definitions = definitionsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedDefinitions, definitions);
+            Assert.That(definitions, Is.EquivalentTo(expectedDefinitions));
 
             var expectedHyperlinks = new string[] {};
             var hyperlinksArray = (JArray) timeOfDayParameterType[PropertyNames.HyperLink];
             IList<string> h = hyperlinksArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedHyperlinks, h);
+            Assert.That(h, Is.EquivalentTo(expectedHyperlinks));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/UnitFactor/UnitFactorTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/UnitFactor/UnitFactorTestFixture.cs
@@ -107,7 +107,7 @@ namespace WebservicesIntegrationTests
 
             var expectedUnitFactorArray = new List<OrderedItem> { new OrderedItem(2, "7d48eebe-c4e1-4081-ab63-7e4584563708"), new OrderedItem(23307173, "56c30a85-f648-4b31-87d2-153e8a74048b") };
             var unitFactorArray = JsonConvert.DeserializeObject<List<OrderedItem>>(derivedUnit[PropertyNames.UnitFactor].ToString());
-            CollectionAssert.AreEquivalent(expectedUnitFactorArray, unitFactorArray);
+            Assert.That(unitFactorArray, Is.EquivalentTo(expectedUnitFactorArray));
 
             postBodyPath = this.GetPath("Tests/SiteDirectory/UnitFactor/PostReorderUnitFactor.json");
 
@@ -130,7 +130,7 @@ namespace WebservicesIntegrationTests
 
             expectedUnitFactorArray = new List<OrderedItem> { new OrderedItem(1, "56c30a85-f648-4b31-87d2-153e8a74048b"), new OrderedItem(3, "7d48eebe-c4e1-4081-ab63-7e4584563708") };
             unitFactorArray = JsonConvert.DeserializeObject<List<OrderedItem>>(derivedUnit[PropertyNames.UnitFactor].ToString());
-            CollectionAssert.AreEquivalent(expectedUnitFactorArray, unitFactorArray);
+            Assert.That(unitFactorArray, Is.EquivalentTo(expectedUnitFactorArray));
         }
 
         /// <summary>

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/UnitPrefix/UnitPrefixTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/UnitPrefix/UnitPrefixTestFixture.cs
@@ -102,17 +102,17 @@ namespace WebservicesIntegrationTests
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) unitPrefix["alias"];
             IList<string> aliases = aliasesArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedAliases, aliases);
+            Assert.That(aliases, Is.EquivalentTo(expectedAliases));
 
             var expectedDefinitions = new string[] {};
             var definitionsArray = (JArray) unitPrefix["definition"];
             IList<string> definitions = definitionsArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedDefinitions, definitions);
+            Assert.That(definitions, Is.EquivalentTo(expectedDefinitions));
 
             var expectedHyperlinks = new string[] {};
             var hyperlinksArray = (JArray) unitPrefix["hyperLink"];
             IList<string> h = hyperlinksArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEquivalent(expectedHyperlinks, h);
+            Assert.That(h, Is.EquivalentTo(expectedHyperlinks));
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace usage of `CollectionAssert.AreEquivalent` with `Assert.That(..., Is.EquivalentTo(...))` across engineering model and site directory integration tests to use modern NUnit syntax

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8daf636748326b0abfc9c697ccd3a