### PR TITLE
Refactor NUnit assertions to Assert.That

### DIFF
--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ActualFiniteStateList/ActualFiniteStateListTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ActualFiniteStateList/ActualFiniteStateListTestFixture.cs
@@ -348,7 +348,7 @@ namespace WebservicesIntegrationTests
             var possibleStateArray = (JArray) actualFiniteState[PropertyNames.PossibleState];
 
             IList<string> possibleStates = possibleStateArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEqual(expectedPossibleStates, possibleStates);
+            Assert.That(possibleStates, Is.EqualTo(expectedPossibleStates));
 
             // get a ActualFiniteStateList from the result by unknown id
             actualFiniteState = jArray.Single(
@@ -371,7 +371,7 @@ namespace WebservicesIntegrationTests
 
             possibleStateArray = (JArray) actualFiniteState[PropertyNames.PossibleState];
             possibleStates = possibleStateArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEqual(expectedPossibleStates, possibleStates);
+            Assert.That(possibleStates, Is.EqualTo(expectedPossibleStates));
 
             // Reorder containment
             postBodyPath = this.GetPath("Tests/EngineeringModel/ActualFiniteStateList/PostActualFiniteStateListRearrangePossibleFiniteStateList.json");
@@ -460,7 +460,7 @@ namespace WebservicesIntegrationTests
             var expectedPossibleStates = new[] { "20f4d6aa-f9d3-4e91-aae9-bfbe77ae9b79" };
             var possibleStateArray = (JArray) actualFiniteState1[PropertyNames.PossibleState];
             IList<string> possibleStates = possibleStateArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEqual(expectedPossibleStates, possibleStates);
+            Assert.That(possibleStates, Is.EqualTo(expectedPossibleStates));
 
             // get a specific ActualFiniteStateList from the result by unknown id
             var actualFiniteState2 = jArray.Single(
@@ -478,7 +478,7 @@ namespace WebservicesIntegrationTests
             expectedPossibleStates = new[] { "b8fdfac4-1c40-475a-ac6c-968654b689b6" };
             possibleStateArray = (JArray) actualFiniteState2[PropertyNames.PossibleState];
             possibleStates = possibleStateArray.Select(x => (string) x).ToList();
-            CollectionAssert.AreEqual(expectedPossibleStates, possibleStates);
+            Assert.That(possibleStates, Is.EqualTo(expectedPossibleStates));
         }
 
         /// <summary>

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ArrayParameterType/MRDLArrayParameterTypeTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ArrayParameterType/MRDLArrayParameterTypeTestFixture.cs
@@ -60,7 +60,7 @@ namespace WebservicesIntegrationTests
             var component_2 = jArray.Single(x => (string) x[PropertyNames.Iid] == "0715f517-1f8b-462d-9189-b4ff20548266");
             Assert.That((int)component_2[PropertyNames.RevisionNumber], Is.EqualTo(2));
             Assert.That((string)component_2[PropertyNames.ParameterType], Is.EqualTo("35a9cf05-4eba-4cda-b60c-7cfeaac8f892"));
-            Assert.IsNull((string) component_2[PropertyNames.Scale]);
+            Assert.That((string) component_2[PropertyNames.Scale], Is.Null);
             Assert.That((string)component_2[PropertyNames.ShortName], Is.EqualTo("{2;1}"));
 
             // Test created because of bug gh373 in github

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/CommonFileStoreFile/CommonFileStoreFileTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/CommonFileStoreFile/CommonFileStoreFileTestFixture.cs
@@ -259,7 +259,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string)fileRevision[PropertyNames.ClassKind], Is.EqualTo("FileRevision"));
             Assert.That((string)fileRevision[PropertyNames.Name], Is.EqualTo("Revision 2_1525ED651E5B609DAE099DEEDA8DBDB49CFF956F"));
 
-            Assert.IsNull((string)fileRevision[PropertyNames.ContainingFolder]);
+            Assert.That((string)fileRevision[PropertyNames.ContainingFolder], Is.Null);
             Assert.That((string)fileRevision[PropertyNames.Creator], Is.EqualTo("284334dd-e8e5-42d6-bc8a-715c507a7f02"));
             Assert.That((string)fileRevision[PropertyNames.ContentHash], Is.EqualTo("1525ED651E5B609DAE099DEEDA8DBDB49CFF956F"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/DomainFileStoreFile/DomainFileStoreFileTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/DomainFileStoreFile/DomainFileStoreFileTestFixture.cs
@@ -217,7 +217,7 @@ namespace WebservicesIntegrationTests
                             Assert.That((string)fileRevision[PropertyNames.ClassKind], Is.EqualTo("FileRevision"));
             Assert.That((string)fileRevision[PropertyNames.Name], Is.EqualTo("FileTest"));
 
-            Assert.IsNull((string) fileRevision[PropertyNames.ContainingFolder]);
+            Assert.That((string) fileRevision[PropertyNames.ContainingFolder], Is.Null);
             Assert.That((string)fileRevision[PropertyNames.Creator], Is.EqualTo("284334dd-e8e5-42d6-bc8a-715c507a7f02"));
             Assert.That((string)fileRevision[PropertyNames.ContentHash], Is.EqualTo("2990BA2444A937A28E7B1E2465FCDF949B8F5368"));
 
@@ -266,7 +266,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string)fileRevision[PropertyNames.ClassKind], Is.EqualTo("FileRevision"));
             Assert.That((string)fileRevision[PropertyNames.Name], Is.EqualTo("Revision 2_1525ED651E5B609DAE099DEEDA8DBDB49CFF956F"));
 
-            Assert.IsNull((string) fileRevision[PropertyNames.ContainingFolder]);
+            Assert.That((string) fileRevision[PropertyNames.ContainingFolder], Is.Null);
             Assert.That((string)fileRevision[PropertyNames.Creator], Is.EqualTo("284334dd-e8e5-42d6-bc8a-715c507a7f02"));
             Assert.That((string)fileRevision[PropertyNames.ContentHash], Is.EqualTo("1525ED651E5B609DAE099DEEDA8DBDB49CFF956F"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ExternalIdentifierMap/ExternalIdentifierMapTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ExternalIdentifierMap/ExternalIdentifierMapTestFixture.cs
@@ -95,7 +95,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string)externalIdentifierMap[PropertyNames.Name], Is.EqualTo("TestExternalIdentifierMap"));
             Assert.That((string)externalIdentifierMap[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
-            Assert.IsNull((string) externalIdentifierMap[PropertyNames.ExternalFormat]);
+            Assert.That((string) externalIdentifierMap[PropertyNames.ExternalFormat], Is.Null);
             Assert.That((string)externalIdentifierMap[PropertyNames.ExternalToolVersion], Is.EqualTo("1.0"));
             Assert.That((string)externalIdentifierMap[PropertyNames.ExternalToolName], Is.EqualTo("externalTool"));
             Assert.That((string)externalIdentifierMap[PropertyNames.ExternalModelName], Is.EqualTo("externalModel"));

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/FileRevision/FileRevisionTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/FileRevision/FileRevisionTestFixture.cs
@@ -125,7 +125,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string)fileRevision[PropertyNames.Name], Is.EqualTo("FileRevision"));
             Assert.That((string)fileRevision[PropertyNames.CreatedOn], Is.EqualTo("2016-11-02T13:58:35.936Z"));
 
-            Assert.IsNull((string) fileRevision[PropertyNames.ContainingFolder]);
+            Assert.That((string) fileRevision[PropertyNames.ContainingFolder], Is.Null);
             Assert.That((string)fileRevision[PropertyNames.Creator], Is.EqualTo("284334dd-e8e5-42d6-bc8a-715c507a7f02"));
             Assert.That((string)fileRevision[PropertyNames.ContentHash], Is.EqualTo("B95EC201AE3EE89D407449D692E69BB97C228A7E"));
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/IdCorrespondence/IdCorrespondenceTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/IdCorrespondence/IdCorrespondenceTestFixture.cs
@@ -97,7 +97,7 @@ namespace WebservicesIntegrationTests
             Assert.That((string)idCorrespondence[PropertyNames.ClassKind], Is.EqualTo("IdCorrespondence"));
 
             Assert.That((string)idCorrespondence[PropertyNames.ExternalId], Is.EqualTo("internalThing"));
-            Assert.AreEqual("35a8ee03-6786-4c39-967d-3c5b438f0c64", (string) idCorrespondence[PropertyNames.InternalThing]);
+            Assert.That((string) idCorrespondence[PropertyNames.InternalThing], Is.EqualTo("35a8ee03-6786-4c39-967d-3c5b438f0c64"));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Iteration/IterationTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Iteration/IterationTestFixture.cs
@@ -528,7 +528,7 @@ namespace WebservicesIntegrationTests
                 Assert.That((string)iteration[PropertyNames.ClassKind], Is.EqualTo("Iteration"));
 
                 Assert.That((string)iteration[PropertyNames.IterationSetup], Is.EqualTo("86163b0e-8341-4316-94fc-93ed60ad0dcf"));
-                Assert.IsNull((string)iteration[PropertyNames.SourceIterationIid]);
+                Assert.That((string)iteration[PropertyNames.SourceIterationIid], Is.Null);
             });
 
             var expectedOptions = new List<OrderedItem>

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ModelLogEntry/ModelLogEntryTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ModelLogEntry/ModelLogEntryTestFixture.cs
@@ -60,7 +60,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(modelLogEntryUri);
 
             //check if there are 2 objects
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             // get a specific ModelLogEntry from the result by it's unique id
             var modelLogEntry = jArray.Single(x => (string) x[PropertyNames.Iid] == "4e2375eb-8e37-4df2-9c7b-dd896683a891");
@@ -77,18 +77,18 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken modelLogEntry)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(11, modelLogEntry.Children().Count());
+            Assert.That(modelLogEntry.Children().Count(), Is.EqualTo(11));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("4e2375eb-8e37-4df2-9c7b-dd896683a891", (string) modelLogEntry[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) modelLogEntry[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ModelLogEntry", (string) modelLogEntry[PropertyNames.ClassKind]);
+            Assert.That((string) modelLogEntry[PropertyNames.Iid], Is.EqualTo("4e2375eb-8e37-4df2-9c7b-dd896683a891"));
+            Assert.That((int) modelLogEntry[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) modelLogEntry[PropertyNames.ClassKind], Is.EqualTo("ModelLogEntry"));
 
-            Assert.AreEqual("TRACE", (string) modelLogEntry[PropertyNames.Level]);
-            Assert.IsNull((string) modelLogEntry[PropertyNames.Author]);
-            Assert.AreEqual("2016-11-07T09:08:36.186Z", (string) modelLogEntry[PropertyNames.CreatedOn]);
-            Assert.AreEqual("testContent", (string) modelLogEntry[PropertyNames.Content]);
-            Assert.AreEqual("en", (string) modelLogEntry[PropertyNames.LanguageCode]);
+            Assert.That((string) modelLogEntry[PropertyNames.Level], Is.EqualTo("TRACE"));
+            Assert.That((string) modelLogEntry[PropertyNames.Author], Is.Null);
+            Assert.That((string) modelLogEntry[PropertyNames.CreatedOn], Is.EqualTo("2016-11-07T09:08:36.186Z"));
+            Assert.That((string) modelLogEntry[PropertyNames.Content], Is.EqualTo("testContent"));
+            Assert.That((string) modelLogEntry[PropertyNames.LanguageCode], Is.EqualTo("en"));
 
             var expectedCategories = new string[] {};
             var categoriesArray = (JArray) modelLogEntry[PropertyNames.Category];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/NotExpression/NotExpressionTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/NotExpression/NotExpressionTestFixture.cs
@@ -60,7 +60,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(notExpressionUri);
 
             // verify that the correct amount of objects is returned
-            Assert.AreEqual(6, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(6));
 
             // get a specific Iteration from the result by it's unique id
             var iteration = jArray.Single(x => (string) x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
@@ -95,13 +95,13 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken notExpression)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(4, notExpression.Children().Count());
+            Assert.That(notExpression.Children().Count(), Is.EqualTo(4));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("30cb785a-9e72-477f-ad1a-8df6ab623e3d", (string) notExpression[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) notExpression[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("NotExpression", (string) notExpression[PropertyNames.ClassKind]);
-            Assert.AreEqual("5f90327f-95a2-4c5a-9efe-581f8daf08ed", (string) notExpression[PropertyNames.Term]);
+            Assert.That((string) notExpression[PropertyNames.Iid], Is.EqualTo("30cb785a-9e72-477f-ad1a-8df6ab623e3d"));
+            Assert.That((int) notExpression[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) notExpression[PropertyNames.ClassKind], Is.EqualTo("NotExpression"));
+            Assert.That((string) notExpression[PropertyNames.Term], Is.EqualTo("5f90327f-95a2-4c5a-9efe-581f8daf08ed"));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Note/NoteTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Note/NoteTestFixture.cs
@@ -77,7 +77,7 @@ namespace WebservicesIntegrationTests
 
             var page = jArray.Single(x => (string) x[PropertyNames.Iid] == "663114f6-9bb1-4751-a3ed-60bad354913e");
 
-            Assert.AreEqual(12, page.Children().Count());
+            Assert.That(page.Children().Count(), Is.EqualTo(12));
 
             var noteList = JsonConvert.DeserializeObject<List<OrderedItem>>(
                 page[PropertyNames.Note].ToString());
@@ -94,8 +94,8 @@ namespace WebservicesIntegrationTests
             var note1 = jArray.Single(x => (string) x[PropertyNames.Iid] == "ab5ddcfb-6302-400b-bd71-17d64a43c747");
             var note2 = jArray.Single(x => (string) x[PropertyNames.Iid] == "85ab7b55-6af5-48fb-a14a-86d16dfe1b57");
 
-            Assert.AreEqual(12, note1.Children().Count());
-            Assert.AreEqual(12, note2.Children().Count());
+            Assert.That(note1.Children().Count(), Is.EqualTo(12));
+            Assert.That(note2.Children().Count(), Is.EqualTo(12));
 
             postBodyPath = this.GetPath("Tests/EngineeringModel/Note/PostDeleteNote.json");
             postBody = this.GetJsonFromFile(postBodyPath);
@@ -103,7 +103,7 @@ namespace WebservicesIntegrationTests
 
             page = jArray.Single(x => (string) x[PropertyNames.Iid] == "663114f6-9bb1-4751-a3ed-60bad354913e");
 
-            Assert.AreEqual(12, page.Children().Count());
+            Assert.That(page.Children().Count(), Is.EqualTo(12));
 
             noteList = JsonConvert.DeserializeObject<List<OrderedItem>>(
                 page[PropertyNames.Note].ToString());

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Option/OptionTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Option/OptionTestFixture.cs
@@ -171,7 +171,7 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken option)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(10, option.Children().Count());
+            Assert.That(option.Children().Count(), Is.EqualTo(10));
 
             // assert that the properties are what is expected
             Assert.That((string)option[PropertyNames.Iid], Is.EqualTo("bebcc9f4-ff20-4569-bbf6-d1acf27a8107"));

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/OrExpression/OrExpressionTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/OrExpression/OrExpressionTestFixture.cs
@@ -60,7 +60,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(orExpressionUri);
 
             // verify that the correct amount of objects is returned
-            Assert.AreEqual(6, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(6));
 
             // get a specific Iteration from the result by it's unique id
             var iteration = jArray.Single(x => (string)x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
@@ -92,12 +92,12 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken orExpression)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(4, orExpression.Children().Count());
+            Assert.That(orExpression.Children().Count(), Is.EqualTo(4));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("5f90327f-95a2-4c5a-9efe-581f8daf08ed", (string)orExpression[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int)orExpression[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("OrExpression", (string)orExpression[PropertyNames.ClassKind]);
+            Assert.That((string)orExpression[PropertyNames.Iid], Is.EqualTo("5f90327f-95a2-4c5a-9efe-581f8daf08ed"));
+            Assert.That((int)orExpression[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string)orExpression[PropertyNames.ClassKind], Is.EqualTo("OrExpression"));
 
             var expectedTerms = new string[]
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Page/PageTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Page/PageTestFixture.cs
@@ -68,7 +68,7 @@ namespace WebservicesIntegrationTests
 
             var section = jArray.Single(x => (string) x[PropertyNames.Iid] == "c2eccf19-a040-4756-8298-8678d7149c8f");
 
-            Assert.AreEqual(12, section.Children().Count());
+            Assert.That(section.Children().Count(), Is.EqualTo(12));
 
             var pageList = JsonConvert.DeserializeObject<List<OrderedItem>>(section[PropertyNames.Page].ToString());
 
@@ -84,8 +84,8 @@ namespace WebservicesIntegrationTests
             var section1 = jArray.Single(x => (string) x[PropertyNames.Iid] == "663114f6-9bb1-4751-a3ed-60bad354913e");
             var section2 = jArray.Single(x => (string) x[PropertyNames.Iid] == "ad20d5de-54ae-40de-98fb-bb8d2cd7a4b8");
 
-            Assert.AreEqual(12, section1.Children().Count());
-            Assert.AreEqual(12, section2.Children().Count());
+            Assert.That(section1.Children().Count(), Is.EqualTo(12));
+            Assert.That(section2.Children().Count(), Is.EqualTo(12));
 
             postBodyPath = this.GetPath("Tests/EngineeringModel/Page/PostDeletePage.json");
             postBody = this.GetJsonFromFile(postBodyPath);
@@ -93,7 +93,7 @@ namespace WebservicesIntegrationTests
 
             section = jArray.Single(x => (string) x[PropertyNames.Iid] == "c2eccf19-a040-4756-8298-8678d7149c8f");
 
-            Assert.AreEqual(12, section.Children().Count());
+            Assert.That(section.Children().Count(), Is.EqualTo(12));
 
             pageList = JsonConvert.DeserializeObject<List<OrderedItem>>(
                 section[PropertyNames.Page].ToString());

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Parameter/ParameterTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Parameter/ParameterTestFixture.cs
@@ -43,7 +43,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(parameterUri);
 
             // check if there appropriate amount of Parameter objects 
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             // get a specific Parameter from the result by it's unique id
             var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c");
@@ -62,7 +62,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(parameterUri);
 
             // check if there are appropriate amount of objects
-            Assert.AreEqual(5, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(5));
 
             // get a specific Iteration from the result by it's unique id
             var iteration = jArray.Single(x => (string) x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
@@ -89,12 +89,12 @@ namespace WebservicesIntegrationTests
 
             var engineeeringModel = jArray.Single(x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
 
-            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // get a specific ElementDefinition from the result by it's unique id
             var elementDefinition = jArray.Single(x => (string) x[PropertyNames.Iid] == "f73860b2-12f0-43e4-b8b2-c81862c0a159");
 
-            Assert.AreEqual(2, (int) elementDefinition[PropertyNames.RevisionNumber]);
+            Assert.That((int) elementDefinition[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedParameters = new[]
             {
@@ -111,22 +111,22 @@ namespace WebservicesIntegrationTests
             var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "2cd4eb9c-e92c-41b2-968c-f03ff7010bad");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(14, parameter.Children().Count());
+            Assert.That(parameter.Children().Count(), Is.EqualTo(14));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("2cd4eb9c-e92c-41b2-968c-f03ff7010bad", (string) parameter[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) parameter[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("Parameter", (string) parameter[PropertyNames.ClassKind]);
+            Assert.That((string) parameter[PropertyNames.Iid], Is.EqualTo("2cd4eb9c-e92c-41b2-968c-f03ff7010bad"));
+            Assert.That((int) parameter[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) parameter[PropertyNames.ClassKind], Is.EqualTo("Parameter"));
 
-            Assert.IsNull((string) parameter[PropertyNames.RequestedBy]);
+            Assert.That((string) parameter[PropertyNames.RequestedBy], Is.Null);
             Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
             Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
-            Assert.AreEqual("35a9cf05-4eba-4cda-b60c-7cfeaac8f892", (string) parameter[PropertyNames.ParameterType]);
-            Assert.IsNull((string) parameter[PropertyNames.Scale]);
-            Assert.IsNull((string) parameter[PropertyNames.StateDependence]);
-            Assert.IsNull((string) parameter[PropertyNames.Group]);
+            Assert.That((string) parameter[PropertyNames.ParameterType], Is.EqualTo("35a9cf05-4eba-4cda-b60c-7cfeaac8f892"));
+            Assert.That((string) parameter[PropertyNames.Scale], Is.Null);
+            Assert.That((string) parameter[PropertyNames.StateDependence], Is.Null);
+            Assert.That((string) parameter[PropertyNames.Group], Is.Null);
             Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameter[PropertyNames.Owner]);
+            Assert.That((string) parameter[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             var expectedParameterSubscriptions = new string[] { };
             var parameterSubscriptionsArray = (JArray) parameter[PropertyNames.ParameterSubscription];
@@ -136,29 +136,29 @@ namespace WebservicesIntegrationTests
             // get the created ParameterValueSet as a side effect of creating Parameter from the result by it's unique id
             var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
             IList<string> valueSets = valueSetsArray.Select(x => (string) x).ToList();
-            Assert.AreEqual(1, valueSets.Count);
+            Assert.That(valueSets.Count, Is.EqualTo(1));
 
             var parameterValueSet = jArray.Single(x => (string) x[PropertyNames.Iid] == valueSets[0]);
 
             // verify the amount of returned properties 
-            Assert.AreEqual(11, parameterValueSet.Children().Count());
+            Assert.That(parameterValueSet.Children().Count(), Is.EqualTo(11));
 
             // assert that the properties are what is expected
-            Assert.AreEqual(valueSets[0], (string) parameterValueSet[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) parameterValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParameterValueSet", (string) parameterValueSet[PropertyNames.ClassKind]);
+            Assert.That((string) parameterValueSet[PropertyNames.Iid], Is.EqualTo(valueSets[0]));
+            Assert.That((int) parameterValueSet[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) parameterValueSet[PropertyNames.ClassKind], Is.EqualTo("ParameterValueSet"));
 
-            Assert.AreEqual("MANUAL", (string) parameterValueSet[PropertyNames.ValueSwitch]);
+            Assert.That((string) parameterValueSet[PropertyNames.ValueSwitch], Is.EqualTo("MANUAL"));
 
             const string emptyProperty = "[\"-\"]";
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Published]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Reference]);
+            Assert.That((string) parameterValueSet[PropertyNames.Published], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Formula], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Computed], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Manual], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Reference], Is.EqualTo(emptyProperty));
 
-            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualState]);
-            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualOption]);
+            Assert.That((string) parameterValueSet[PropertyNames.ActualState], Is.Null);
+            Assert.That((string) parameterValueSet[PropertyNames.ActualOption], Is.Null);
         }
 
         [Test]
@@ -243,12 +243,12 @@ namespace WebservicesIntegrationTests
 
             var engineeeringModel = jArray.Single(x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
 
-            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // get a specific ElementDefinition from the result by it's unique id
             var elementDefinition = jArray.Single(x => (string) x[PropertyNames.Iid] == "f73860b2-12f0-43e4-b8b2-c81862c0a159");
 
-            Assert.AreEqual(2, (int) elementDefinition[PropertyNames.RevisionNumber]);
+            Assert.That((int) elementDefinition[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedParameters = new[]
             {
@@ -264,22 +264,22 @@ namespace WebservicesIntegrationTests
             var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "2cd4eb9c-e92c-41b2-968c-f03ff7010bad");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(14, parameter.Children().Count());
+            Assert.That(parameter.Children().Count(), Is.EqualTo(14));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("2cd4eb9c-e92c-41b2-968c-f03ff7010bad", (string) parameter[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) parameter[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("Parameter", (string) parameter[PropertyNames.ClassKind]);
+            Assert.That((string) parameter[PropertyNames.Iid], Is.EqualTo("2cd4eb9c-e92c-41b2-968c-f03ff7010bad"));
+            Assert.That((int) parameter[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) parameter[PropertyNames.ClassKind], Is.EqualTo("Parameter"));
 
-            Assert.IsNull((string) parameter[PropertyNames.RequestedBy]);
+            Assert.That((string) parameter[PropertyNames.RequestedBy], Is.Null);
             Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
             Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
-            Assert.AreEqual("35a9cf05-4eba-4cda-b60c-7cfeaac8f892", (string) parameter[PropertyNames.ParameterType]);
-            Assert.IsNull((string) parameter[PropertyNames.Scale]);
-            Assert.IsNull((string) parameter[PropertyNames.StateDependence]);
-            Assert.IsNull((string) parameter[PropertyNames.Group]);
+            Assert.That((string) parameter[PropertyNames.ParameterType], Is.EqualTo("35a9cf05-4eba-4cda-b60c-7cfeaac8f892"));
+            Assert.That((string) parameter[PropertyNames.Scale], Is.Null);
+            Assert.That((string) parameter[PropertyNames.StateDependence], Is.Null);
+            Assert.That((string) parameter[PropertyNames.Group], Is.Null);
             Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameter[PropertyNames.Owner]);
+            Assert.That((string) parameter[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             var expectedParameterSubscriptions = new string[] { };
             var parameterSubscriptionsArray = (JArray) parameter[PropertyNames.ParameterSubscription];
@@ -289,29 +289,29 @@ namespace WebservicesIntegrationTests
             // get the created ParameterValueSet as a side effect of creating Parameter from the result by it's unique id
             var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
             IList<string> valueSets = valueSetsArray.Select(x => (string) x).ToList();
-            Assert.AreEqual(1, valueSets.Count);
+            Assert.That(valueSets.Count, Is.EqualTo(1));
 
             var parameterValueSet = jArray.Single(x => (string) x[PropertyNames.Iid] == valueSets[0]);
 
             // verify the amount of returned properties 
-            Assert.AreEqual(11, parameterValueSet.Children().Count());
+            Assert.That(parameterValueSet.Children().Count(), Is.EqualTo(11));
 
             // assert that the properties are what is expected
-            Assert.AreEqual(valueSets[0], (string) parameterValueSet[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) parameterValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParameterValueSet", (string) parameterValueSet[PropertyNames.ClassKind]);
+            Assert.That((string) parameterValueSet[PropertyNames.Iid], Is.EqualTo(valueSets[0]));
+            Assert.That((int) parameterValueSet[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) parameterValueSet[PropertyNames.ClassKind], Is.EqualTo("ParameterValueSet"));
 
-            Assert.AreEqual("MANUAL", (string) parameterValueSet[PropertyNames.ValueSwitch]);
+            Assert.That((string) parameterValueSet[PropertyNames.ValueSwitch], Is.EqualTo("MANUAL"));
 
             const string emptyProperty = "[\"-\"]";
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Published]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Reference]);
+            Assert.That((string) parameterValueSet[PropertyNames.Published], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Formula], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Computed], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Manual], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Reference], Is.EqualTo(emptyProperty));
 
-            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualState]);
-            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualOption]);
+            Assert.That((string) parameterValueSet[PropertyNames.ActualState], Is.Null);
+            Assert.That((string) parameterValueSet[PropertyNames.ActualOption], Is.Null);
         }
 
         [Test]
@@ -327,12 +327,12 @@ namespace WebservicesIntegrationTests
 
             var engineeeringModel = jArray.Single(x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
 
-            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // get a specific ElementDefinition from the result by it's unique id
             var elementDefinition = jArray.Single(x => (string) x[PropertyNames.Iid] == "f73860b2-12f0-43e4-b8b2-c81862c0a159");
 
-            Assert.AreEqual(2, (int) elementDefinition[PropertyNames.RevisionNumber]);
+            Assert.That((int) elementDefinition[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedParameters = new[]
             {
@@ -349,22 +349,22 @@ namespace WebservicesIntegrationTests
             var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "2460b6a5-08ff-4cc3-a2cc-8fd5c5cf2736");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(14, parameter.Children().Count());
+            Assert.That(parameter.Children().Count(), Is.EqualTo(14));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("2460b6a5-08ff-4cc3-a2cc-8fd5c5cf2736", (string) parameter[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) parameter[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("Parameter", (string) parameter[PropertyNames.ClassKind]);
+            Assert.That((string) parameter[PropertyNames.Iid], Is.EqualTo("2460b6a5-08ff-4cc3-a2cc-8fd5c5cf2736"));
+            Assert.That((int) parameter[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) parameter[PropertyNames.ClassKind], Is.EqualTo("Parameter"));
 
-            Assert.IsNull((string) parameter[PropertyNames.RequestedBy]);
+            Assert.That((string) parameter[PropertyNames.RequestedBy], Is.Null);
             Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
             Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
-            Assert.AreEqual("4a783624-b2bc-4e6d-95b3-11d036f6e917", (string) parameter[PropertyNames.ParameterType]);
-            Assert.IsNull((string) parameter[PropertyNames.Scale]);
-            Assert.IsNull((string) parameter[PropertyNames.StateDependence]);
-            Assert.IsNull((string) parameter[PropertyNames.Group]);
+            Assert.That((string) parameter[PropertyNames.ParameterType], Is.EqualTo("4a783624-b2bc-4e6d-95b3-11d036f6e917"));
+            Assert.That((string) parameter[PropertyNames.Scale], Is.Null);
+            Assert.That((string) parameter[PropertyNames.StateDependence], Is.Null);
+            Assert.That((string) parameter[PropertyNames.Group], Is.Null);
             Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameter[PropertyNames.Owner]);
+            Assert.That((string) parameter[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             var expectedParameterSubscriptions = new string[] { };
             var parameterSubscriptionsArray = (JArray) parameter[PropertyNames.ParameterSubscription];
@@ -374,29 +374,29 @@ namespace WebservicesIntegrationTests
             // get the created ParameterValueSet as a side effect of creating Parameter from the result by it's unique id
             var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
             IList<string> valueSets = valueSetsArray.Select(x => (string) x).ToList();
-            Assert.AreEqual(1, valueSets.Count);
+            Assert.That(valueSets.Count, Is.EqualTo(1));
 
             var parameterValueSet = jArray.Single(x => (string) x[PropertyNames.Iid] == valueSets[0]);
 
             // verify the amount of returned properties 
-            Assert.AreEqual(11, parameterValueSet.Children().Count());
+            Assert.That(parameterValueSet.Children().Count(), Is.EqualTo(11));
 
             // assert that the properties are what is expected
-            Assert.AreEqual(valueSets[0], (string) parameterValueSet[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) parameterValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParameterValueSet", (string) parameterValueSet[PropertyNames.ClassKind]);
+            Assert.That((string) parameterValueSet[PropertyNames.Iid], Is.EqualTo(valueSets[0]));
+            Assert.That((int) parameterValueSet[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) parameterValueSet[PropertyNames.ClassKind], Is.EqualTo("ParameterValueSet"));
 
-            Assert.AreEqual("MANUAL", (string) parameterValueSet[PropertyNames.ValueSwitch]);
+            Assert.That((string) parameterValueSet[PropertyNames.ValueSwitch], Is.EqualTo("MANUAL"));
 
             const string emptyProperty = "[\"-\",\"-\"]";
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Published]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Reference]);
+            Assert.That((string) parameterValueSet[PropertyNames.Published], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Formula], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Computed], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Manual], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Reference], Is.EqualTo(emptyProperty));
 
-            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualState]);
-            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualOption]);
+            Assert.That((string) parameterValueSet[PropertyNames.ActualState], Is.Null);
+            Assert.That((string) parameterValueSet[PropertyNames.ActualOption], Is.Null);
         }
 
         [Test]
@@ -411,12 +411,12 @@ namespace WebservicesIntegrationTests
 
             var engineeeringModel = jArray.Single(x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
 
-            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // get a specific ElementDefinition from the result by it's unique id
             var elementDefinition = jArray.Single(x => (string) x[PropertyNames.Iid] == "f73860b2-12f0-43e4-b8b2-c81862c0a159");
 
-            Assert.AreEqual(2, (int) elementDefinition[PropertyNames.RevisionNumber]);
+            Assert.That((int) elementDefinition[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedParameters = new[]
             {
@@ -433,22 +433,22 @@ namespace WebservicesIntegrationTests
             var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "9600b225-a4be-47b1-92b1-4dc2d8894ea3");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(14, parameter.Children().Count());
+            Assert.That(parameter.Children().Count(), Is.EqualTo(14));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("9600b225-a4be-47b1-92b1-4dc2d8894ea3", (string) parameter[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) parameter[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("Parameter", (string) parameter[PropertyNames.ClassKind]);
+            Assert.That((string) parameter[PropertyNames.Iid], Is.EqualTo("9600b225-a4be-47b1-92b1-4dc2d8894ea3"));
+            Assert.That((int) parameter[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) parameter[PropertyNames.ClassKind], Is.EqualTo("Parameter"));
 
-            Assert.IsNull((string) parameter[PropertyNames.RequestedBy]);
+            Assert.That((string) parameter[PropertyNames.RequestedBy], Is.Null);
             Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
             Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
-            Assert.AreEqual("35a9cf05-4eba-4cda-b60c-7cfeaac8f892", (string) parameter[PropertyNames.ParameterType]);
-            Assert.IsNull((string) parameter[PropertyNames.Scale]);
-            Assert.IsNull((string) parameter[PropertyNames.StateDependence]);
-            Assert.IsNull((string) parameter[PropertyNames.Group]);
+            Assert.That((string) parameter[PropertyNames.ParameterType], Is.EqualTo("35a9cf05-4eba-4cda-b60c-7cfeaac8f892"));
+            Assert.That((string) parameter[PropertyNames.Scale], Is.Null);
+            Assert.That((string) parameter[PropertyNames.StateDependence], Is.Null);
+            Assert.That((string) parameter[PropertyNames.Group], Is.Null);
             Assert.IsTrue((bool) parameter[PropertyNames.IsOptionDependent]);
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameter[PropertyNames.Owner]);
+            Assert.That((string) parameter[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             var expectedParameterSubscriptions = new string[] { };
             var parameterSubscriptionsArray = (JArray) parameter[PropertyNames.ParameterSubscription];
@@ -458,32 +458,30 @@ namespace WebservicesIntegrationTests
             // get the created ParameterValueSet as a side effect of creating Parameter from the result by it's unique id
             var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
             IList<string> valueSets = valueSetsArray.Select(x => (string) x).ToList();
-            Assert.AreEqual(1, valueSets.Count);
+            Assert.That(valueSets.Count, Is.EqualTo(1));
 
             var parameterValueSet = jArray.Single(x => (string) x[PropertyNames.Iid] == valueSets[0]);
 
             // verify the amount of returned properties 
-            Assert.AreEqual(11, parameterValueSet.Children().Count());
+            Assert.That(parameterValueSet.Children().Count(), Is.EqualTo(11));
 
             // assert that the properties are what is expected
-            Assert.AreEqual(valueSets[0], (string) parameterValueSet[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) parameterValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParameterValueSet", (string) parameterValueSet[PropertyNames.ClassKind]);
+            Assert.That((string) parameterValueSet[PropertyNames.Iid], Is.EqualTo(valueSets[0]));
+            Assert.That((int) parameterValueSet[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) parameterValueSet[PropertyNames.ClassKind], Is.EqualTo("ParameterValueSet"));
 
-            Assert.AreEqual("MANUAL", (string) parameterValueSet[PropertyNames.ValueSwitch]);
+            Assert.That((string) parameterValueSet[PropertyNames.ValueSwitch], Is.EqualTo("MANUAL"));
 
             const string emptyProperty = "[\"-\"]";
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Published]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(emptyProperty, (string) parameterValueSet[PropertyNames.Reference]);
+            Assert.That((string) parameterValueSet[PropertyNames.Published], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Formula], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Computed], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Manual], Is.EqualTo(emptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Reference], Is.EqualTo(emptyProperty));
 
-            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualState]);
+            Assert.That((string) parameterValueSet[PropertyNames.ActualState], Is.Null);
 
-            Assert.AreEqual(
-                "bebcc9f4-ff20-4569-bbf6-d1acf27a8107",
-                (string) parameterValueSet[PropertyNames.ActualOption]);
+            Assert.That((string) parameterValueSet[PropertyNames.ActualOption], Is.EqualTo("bebcc9f4-ff20-4569-bbf6-d1acf27a8107"));
         }
 
         [Test]
@@ -498,39 +496,33 @@ namespace WebservicesIntegrationTests
 
             var engineeeringModel = jArray.Single(x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
 
-            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var parameterValueSet = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterValueSet");
-            Assert.AreEqual(2, (int) parameterValueSet[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameterValueSet[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var parameterOverrideValueSet = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterOverrideValueSet");
 
-            Assert.AreEqual(2, (int) parameterOverrideValueSet[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameterOverrideValueSet[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
-            Assert.AreEqual(
-                (string) parameterValueSet[PropertyNames.Iid],
-                (string) parameterOverrideValueSet[PropertyNames.ParameterValueSet]);
+            Assert.That((string) parameterOverrideValueSet[PropertyNames.ParameterValueSet], Is.EqualTo((string) parameterValueSet[PropertyNames.Iid]));
 
             var parameterSubscriptionValueSet =
                 jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterSubscriptionValueSet");
 
-            Assert.AreEqual(2, (int) parameterSubscriptionValueSet[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameterSubscriptionValueSet[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
-            Assert.AreEqual(
-                (string) parameterValueSet[PropertyNames.Iid],
-                (string) parameterSubscriptionValueSet[PropertyNames.SubscribedValueSet]);
+            Assert.That((string) parameterSubscriptionValueSet[PropertyNames.SubscribedValueSet], Is.EqualTo((string) parameterValueSet[PropertyNames.Iid]));
 
             var parameterSubscription = jArray.Single(
                 x => (string) x[PropertyNames.Iid] == "f1f076c4-5307-42b8-a171-3263a9e7bb21");
 
-            Assert.AreEqual(2, (int) parameterSubscription[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameterSubscription[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
-            Assert.AreEqual(
-                (string) parameterSubscriptionValueSet[PropertyNames.Iid],
-                (string) parameterSubscription[PropertyNames.ValueSet][0]);
+            Assert.That((string) parameterSubscription[PropertyNames.ValueSet][0], Is.EqualTo((string) parameterSubscriptionValueSet[PropertyNames.Iid]));
 
             var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c");
-            Assert.AreEqual(2, (int) parameter[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameter[PropertyNames.RevisionNumber], Is.EqualTo(2));
             var expectedValueSets = new[] { (string) parameterValueSet[PropertyNames.Iid] };
             var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
             IList<string> valueSets = valueSetsArray.Select(x => (string) x).ToList();
@@ -539,7 +531,7 @@ namespace WebservicesIntegrationTests
             var parameterOverride = jArray.Single(
                 x => (string) x[PropertyNames.Iid] == "93f767ed-4d22-45f6-ae97-d1dab0d36e1c");
 
-            Assert.AreEqual(2, (int) parameterOverride[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameterOverride[PropertyNames.RevisionNumber], Is.EqualTo(2));
             expectedValueSets = new[] { (string) parameterOverrideValueSet[PropertyNames.Iid] };
             valueSetsArray = (JArray) parameterOverride[PropertyNames.ValueSet];
             valueSets = valueSetsArray.Select(x => (string) x).ToList();
@@ -559,32 +551,30 @@ namespace WebservicesIntegrationTests
             var engineeeringModel = jArray.Single(
                 x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
 
-            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var parameterValueSet = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterValueSet");
-            Assert.AreEqual(2, (int) parameterValueSet[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameterValueSet[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             const string EmptyProperty = "[\"-\"]";
-            Assert.AreEqual("MANUAL", (string) parameterValueSet[PropertyNames.ValueSwitch]);
-            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Published]);
-            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Reference]);
+            Assert.That((string) parameterValueSet[PropertyNames.ValueSwitch], Is.EqualTo("MANUAL"));
+            Assert.That((string) parameterValueSet[PropertyNames.Published], Is.EqualTo(EmptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Formula], Is.EqualTo(EmptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Computed], Is.EqualTo(EmptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Manual], Is.EqualTo(EmptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Reference], Is.EqualTo(EmptyProperty));
 
-            Assert.AreEqual(
-                "b91bfdbb-4277-4a03-b519-e4db839ef5d4",
-                (string) parameterValueSet[PropertyNames.ActualState]);
+            Assert.That((string) parameterValueSet[PropertyNames.ActualState], Is.EqualTo("b91bfdbb-4277-4a03-b519-e4db839ef5d4"));
 
-            Assert.IsNull((string) parameterValueSet[PropertyNames.ActualOption]);
+            Assert.That((string) parameterValueSet[PropertyNames.ActualOption], Is.Null);
 
             var parameterOverride = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterOverride");
-            Assert.AreEqual(2, (int) parameterOverride[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameterOverride[PropertyNames.RevisionNumber], Is.EqualTo(2));
             var valueSetsArray = (JArray) parameterOverride[PropertyNames.ValueSet];
             var valueSets = valueSetsArray.Select(x => (string) x).ToList();
-            Assert.AreEqual(1, valueSets.Count);
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameterOverride[PropertyNames.Owner]);
-            Assert.AreEqual("6c5aff74-f983-4aa8-a9d6-293b3429307c", (string) parameterOverride[PropertyNames.Parameter]);
+            Assert.That(valueSets.Count, Is.EqualTo(1));
+            Assert.That((string) parameterOverride[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
+            Assert.That((string) parameterOverride[PropertyNames.Parameter], Is.EqualTo("6c5aff74-f983-4aa8-a9d6-293b3429307c"));
 
             var expectedParameterSubscriptions = new string[] { };
             var parameterSubscriptionsArray = (JArray) parameterOverride[PropertyNames.ParameterSubscription];
@@ -594,53 +584,47 @@ namespace WebservicesIntegrationTests
             var parameterOverrideValueSet = jArray.Single(
                 x => (string) x[PropertyNames.Iid] == (string) parameterOverride[PropertyNames.ValueSet][0]);
 
-            Assert.AreEqual(2, (int) parameterOverrideValueSet[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameterOverrideValueSet[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
-            Assert.AreEqual(
-                (string) parameterValueSet[PropertyNames.Iid],
-                (string) parameterOverrideValueSet[PropertyNames.ParameterValueSet]);
+            Assert.That((string) parameterOverrideValueSet[PropertyNames.ParameterValueSet], Is.EqualTo((string) parameterValueSet[PropertyNames.Iid]));
 
-            Assert.AreEqual("MANUAL", (string) parameterOverrideValueSet[PropertyNames.ValueSwitch]);
+            Assert.That((string) parameterOverrideValueSet[PropertyNames.ValueSwitch], Is.EqualTo("MANUAL"));
 
-            Assert.AreEqual(EmptyProperty, (string) parameterOverrideValueSet[PropertyNames.Published]);
-            Assert.AreEqual(EmptyProperty, (string) parameterOverrideValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(EmptyProperty, (string) parameterOverrideValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(EmptyProperty, (string) parameterOverrideValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(EmptyProperty, (string) parameterOverrideValueSet[PropertyNames.Reference]);
+            Assert.That((string) parameterOverrideValueSet[PropertyNames.Published], Is.EqualTo(EmptyProperty));
+            Assert.That((string) parameterOverrideValueSet[PropertyNames.Formula], Is.EqualTo(EmptyProperty));
+            Assert.That((string) parameterOverrideValueSet[PropertyNames.Computed], Is.EqualTo(EmptyProperty));
+            Assert.That((string) parameterOverrideValueSet[PropertyNames.Manual], Is.EqualTo(EmptyProperty));
+            Assert.That((string) parameterOverrideValueSet[PropertyNames.Reference], Is.EqualTo(EmptyProperty));
 
             var parameterSubscription = jArray.Single(
                 x => (string) x[PropertyNames.Iid] == "f1f076c4-5307-42b8-a171-3263a9e7bb21");
 
-            Assert.AreEqual(2, (int) parameterSubscription[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameterOverride[PropertyNames.Owner]);
+            Assert.That((int) parameterSubscription[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) parameterOverride[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             valueSetsArray = (JArray) parameterSubscription[PropertyNames.ValueSet];
             valueSets = valueSetsArray.Select(x => (string) x).ToList();
-            Assert.AreEqual(1, valueSets.Count);
+            Assert.That(valueSets.Count, Is.EqualTo(1));
 
             var parameterSubscriptionValueSet = jArray.Single(
                 x => (string) x[PropertyNames.Iid] == (string) parameterSubscription[PropertyNames.ValueSet][0]);
 
-            Assert.AreEqual(2, (int) parameterSubscriptionValueSet[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameterSubscriptionValueSet[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
-            Assert.AreEqual(
-                (string) parameterValueSet[PropertyNames.Iid],
-                (string) parameterSubscriptionValueSet[PropertyNames.SubscribedValueSet]);
+            Assert.That((string) parameterSubscriptionValueSet[PropertyNames.SubscribedValueSet], Is.EqualTo((string) parameterValueSet[PropertyNames.Iid]));
 
-            Assert.AreEqual(
-                (string) parameterValueSet[PropertyNames.Iid],
-                (string) parameterSubscriptionValueSet[PropertyNames.SubscribedValueSet]);
+            Assert.That((string) parameterSubscriptionValueSet[PropertyNames.SubscribedValueSet], Is.EqualTo((string) parameterValueSet[PropertyNames.Iid]));
 
-            Assert.AreEqual(EmptyProperty, (string) parameterSubscriptionValueSet[PropertyNames.Manual]);
-            Assert.AreEqual("MANUAL", (string) parameterSubscriptionValueSet[PropertyNames.ValueSwitch]);
+            Assert.That((string) parameterSubscriptionValueSet[PropertyNames.Manual], Is.EqualTo(EmptyProperty));
+            Assert.That((string) parameterSubscriptionValueSet[PropertyNames.ValueSwitch], Is.EqualTo("MANUAL"));
 
             var parameter = jArray.Single(x => (string) x[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c");
-            Assert.AreEqual(2, (int) parameter[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameter[PropertyNames.RevisionNumber], Is.EqualTo(2));
             var expectedValueSets = new[] { (string) parameterValueSet[PropertyNames.Iid] };
             valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
             valueSets = valueSetsArray.Select(x => (string) x).ToList();
             Assert.That(valueSets, Is.EquivalentTo(expectedValueSets));
-            Assert.AreEqual("db690d7d-761c-47fd-96d3-840d698a89dc", (string) parameter[PropertyNames.StateDependence]);
+            Assert.That((string) parameter[PropertyNames.StateDependence], Is.EqualTo("db690d7d-761c-47fd-96d3-840d698a89dc"));
         }
 
         [Test]
@@ -655,10 +639,10 @@ namespace WebservicesIntegrationTests
 
             var engineeeringModel = jArray.Single(x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
 
-            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var parameterValueSet = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterValueSet");
-            Assert.AreEqual(2, (int) parameterValueSet[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameterValueSet[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             postBodyPath = this.GetPath("Tests/EngineeringModel/ActualFiniteStateList/PostNewActualFiniteStateList.json");
 
@@ -668,10 +652,10 @@ namespace WebservicesIntegrationTests
             engineeeringModel = jArray.Single(
                 x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
 
-            Assert.AreEqual(3, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             var iteration = jArray.Single(x => (string) x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
-            Assert.AreEqual(3, (int) iteration[PropertyNames.RevisionNumber]);
+            Assert.That((int) iteration[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             postBodyPath = this.GetPath("Tests/EngineeringModel/Parameter/PostUpdateStateDependentParameterToAnotherState.json");
 
@@ -681,27 +665,27 @@ namespace WebservicesIntegrationTests
             engineeeringModel = jArray.Single(
                 x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
 
-            Assert.AreEqual(4, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(4));
 
             parameterValueSet = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterValueSet");
-            Assert.AreEqual(4, (int) parameterValueSet[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameterValueSet[PropertyNames.RevisionNumber], Is.EqualTo(4));
 
             const string EmptyProperty = "[\"-\"]";
-            Assert.AreEqual("MANUAL", (string) parameterValueSet[PropertyNames.ValueSwitch]);
-            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Published]);
-            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(EmptyProperty, (string) parameterValueSet[PropertyNames.Reference]);
+            Assert.That((string) parameterValueSet[PropertyNames.ValueSwitch], Is.EqualTo("MANUAL"));
+            Assert.That((string) parameterValueSet[PropertyNames.Published], Is.EqualTo(EmptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Formula], Is.EqualTo(EmptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Computed], Is.EqualTo(EmptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Manual], Is.EqualTo(EmptyProperty));
+            Assert.That((string) parameterValueSet[PropertyNames.Reference], Is.EqualTo(EmptyProperty));
 
             var parameter = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "Parameter");
-            Assert.AreEqual(4, (int) parameter[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameter[PropertyNames.RevisionNumber], Is.EqualTo(4));
 
             var parameterSubscription = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterSubscription");
-            Assert.AreEqual(4, (int) parameterSubscription[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameterSubscription[PropertyNames.RevisionNumber], Is.EqualTo(4));
 
             var parameterOverride = jArray.Single(x => (string) x[PropertyNames.ClassKind] == "ParameterOverride");
-            Assert.AreEqual(4, (int) parameterOverride[PropertyNames.RevisionNumber]);
+            Assert.That((int) parameterOverride[PropertyNames.RevisionNumber], Is.EqualTo(4));
         }
 
         /// <summary>
@@ -716,22 +700,22 @@ namespace WebservicesIntegrationTests
             if ((string) parameter[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c")
             {
                 // verify the amount of returned properties 
-                Assert.AreEqual(14, parameter.Children().Count());
+                Assert.That(parameter.Children().Count(), Is.EqualTo(14));
 
                 // assert that the properties are what is expected
-                Assert.AreEqual("6c5aff74-f983-4aa8-a9d6-293b3429307c", (string) parameter[PropertyNames.Iid]);
-                Assert.AreEqual(1, (int) parameter[PropertyNames.RevisionNumber]);
-                Assert.AreEqual("Parameter", (string) parameter[PropertyNames.ClassKind]);
+                Assert.That((string) parameter[PropertyNames.Iid], Is.EqualTo("6c5aff74-f983-4aa8-a9d6-293b3429307c"));
+                Assert.That((int) parameter[PropertyNames.RevisionNumber], Is.EqualTo(1));
+                Assert.That((string) parameter[PropertyNames.ClassKind], Is.EqualTo("Parameter"));
 
-                Assert.IsNull((string) parameter[PropertyNames.RequestedBy]);
+                Assert.That((string) parameter[PropertyNames.RequestedBy], Is.Null);
                 Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
                 Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
-                Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254", (string) parameter[PropertyNames.ParameterType]);
-                Assert.IsNull((string) parameter[PropertyNames.Scale]);
-                Assert.IsNull((string) parameter[PropertyNames.StateDependence]);
-                Assert.AreEqual((string) parameter[PropertyNames.Group], "b739b3c6-9cc0-4e64-9cc4-ef7463edf559");
+                Assert.That((string) parameter[PropertyNames.ParameterType], Is.EqualTo("a21c15c4-3e1e-46b5-b109-5063dec1e254"));
+                Assert.That((string) parameter[PropertyNames.Scale], Is.Null);
+                Assert.That((string) parameter[PropertyNames.StateDependence], Is.Null);
+                Assert.That("b739b3c6-9cc0-4e64-9cc4-ef7463edf559", Is.EqualTo((string) parameter[PropertyNames.Group]));
                 Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
-                Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameter[PropertyNames.Owner]);
+                Assert.That((string) parameter[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
                 var expectedValueSets = new[] { "af5c88c6-301f-497b-81f7-53748c3900ed" };
                 var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];
@@ -747,22 +731,22 @@ namespace WebservicesIntegrationTests
             if ((string) parameter[PropertyNames.Iid] == "3f05483f-66ff-4f21-bc76-45956779f66e")
             {
                 // verify the amount of returned properties 
-                Assert.AreEqual(14, parameter.Children().Count());
+                Assert.That(parameter.Children().Count(), Is.EqualTo(14));
 
                 // assert that the properties are what is expected
-                Assert.AreEqual("3f05483f-66ff-4f21-bc76-45956779f66e", (string) parameter[PropertyNames.Iid]);
-                Assert.AreEqual(1, (int) parameter[PropertyNames.RevisionNumber]);
-                Assert.AreEqual("Parameter", (string) parameter[PropertyNames.ClassKind]);
+                Assert.That((string) parameter[PropertyNames.Iid], Is.EqualTo("3f05483f-66ff-4f21-bc76-45956779f66e"));
+                Assert.That((int) parameter[PropertyNames.RevisionNumber], Is.EqualTo(1));
+                Assert.That((string) parameter[PropertyNames.ClassKind], Is.EqualTo("Parameter"));
 
-                Assert.IsNull((string) parameter[PropertyNames.RequestedBy]);
+                Assert.That((string) parameter[PropertyNames.RequestedBy], Is.Null);
                 Assert.IsFalse((bool) parameter[PropertyNames.AllowDifferentOwnerOfOverride]);
                 Assert.IsFalse((bool) parameter[PropertyNames.ExpectsOverride]);
-                Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254", (string) parameter[PropertyNames.ParameterType]);
-                Assert.IsNull((string) parameter[PropertyNames.Scale]);
-                Assert.IsNull((string) parameter[PropertyNames.StateDependence]);
-                Assert.AreEqual((string) parameter[PropertyNames.Group], "b739b3c6-9cc0-4e64-9cc4-ef7463edf559");
+                Assert.That((string) parameter[PropertyNames.ParameterType], Is.EqualTo("a21c15c4-3e1e-46b5-b109-5063dec1e254"));
+                Assert.That((string) parameter[PropertyNames.Scale], Is.Null);
+                Assert.That((string) parameter[PropertyNames.StateDependence], Is.Null);
+                Assert.That("b739b3c6-9cc0-4e64-9cc4-ef7463edf559", Is.EqualTo((string) parameter[PropertyNames.Group]));
                 Assert.IsFalse((bool) parameter[PropertyNames.IsOptionDependent]);
-                Assert.AreEqual("eb759723-14b9-49f4-8611-544d037bb764", (string) parameter[PropertyNames.Owner]);
+                Assert.That((string) parameter[PropertyNames.Owner], Is.EqualTo("eb759723-14b9-49f4-8611-544d037bb764"));
 
                 var expectedValueSets = new[] { "72ec3701-bcb5-4bf6-bd78-30fd1b65e3be" };
                 var valueSetsArray = (JArray) parameter[PropertyNames.ValueSet];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParameterGroup/ParameterGroupTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParameterGroup/ParameterGroupTestFixture.cs
@@ -89,11 +89,11 @@ namespace WebservicesIntegrationTests
             Assert.That(jArray.Count, Is.EqualTo(3));
 
             var engineeeringModel = jArray.Single(x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int)engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int)engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // get a specific ElementDefinition from the result by it's unique id
             var elementDefinition = jArray.Single(x => (string)x[PropertyNames.Iid] == "f73860b2-12f0-43e4-b8b2-c81862c0a159");
-            Assert.AreEqual(2, (int)elementDefinition[PropertyNames.RevisionNumber]);
+            Assert.That((int)elementDefinition[PropertyNames.RevisionNumber], Is.EqualTo(2));
             var expectedParameterGroups = new string[] { };
             var parameterGroupsArray = (JArray)elementDefinition[PropertyNames.ParameterGroup];
             IList<string> parameterGroups = parameterGroupsArray.Select(x => (string)x).ToList();
@@ -101,8 +101,8 @@ namespace WebservicesIntegrationTests
 
             // get a specific Parameter from the result by it's unique id
             var parameter = jArray.Single(x => (string)x[PropertyNames.Iid] == "6c5aff74-f983-4aa8-a9d6-293b3429307c");
-            Assert.AreEqual(2, (int)parameter[PropertyNames.RevisionNumber]);
-            Assert.IsNull((string)parameter[PropertyNames.Group]);
+            Assert.That((int)parameter[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string)parameter[PropertyNames.Group], Is.Null);
         }
 
         /// <summary>
@@ -115,15 +115,15 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken parameterGroup)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(5, parameterGroup.Children().Count());
+            Assert.That(parameterGroup.Children().Count(), Is.EqualTo(5));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("b739b3c6-9cc0-4e64-9cc4-ef7463edf559", (string)parameterGroup[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int)parameterGroup[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParameterGroup", (string)parameterGroup[PropertyNames.ClassKind]);
+            Assert.That((string)parameterGroup[PropertyNames.Iid], Is.EqualTo("b739b3c6-9cc0-4e64-9cc4-ef7463edf559"));
+            Assert.That((int)parameterGroup[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string)parameterGroup[PropertyNames.ClassKind], Is.EqualTo("ParameterGroup"));
 
-            Assert.AreEqual("Test ParameterGroup", (string)parameterGroup[PropertyNames.Name]);
-            Assert.IsNull((string)parameterGroup[PropertyNames.ContainingGroup]);
+            Assert.That((string)parameterGroup[PropertyNames.Name], Is.EqualTo("Test ParameterGroup"));
+            Assert.That((string)parameterGroup[PropertyNames.ContainingGroup], Is.Null);
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParameterOverride/ParameterOverrideTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParameterOverride/ParameterOverrideTestFixture.cs
@@ -110,7 +110,7 @@ namespace WebservicesIntegrationTests
             var parameterOverride = jArray.Single(x => (string)x[PropertyNames.Iid] == "3587bb05-0db4-4741-b5e3-da43393e13ed");
 
             // verify the amount of properties
-            Assert.AreEqual(7, parameterOverride.Children().Count());
+            Assert.That(parameterOverride.Children().Count(), Is.EqualTo(7));
 
             // assert that the properties are what is expected
             Assert.That((string)parameterOverride[PropertyNames.Iid], Is.EqualTo("3587bb05-0db4-4741-b5e3-da43393e13ed"));
@@ -242,7 +242,7 @@ namespace WebservicesIntegrationTests
             jArray = this.WebClient.GetDto(elementUsageUri);
 
             //check if there is the only one ParameterOverride object 
-            Assert.AreEqual(7, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(7));
 
             povs1 = jArray.Single(x => (string)x[PropertyNames.Iid] == (string)parameterOverrideValueSet1[PropertyNames.Iid]);
 
@@ -265,17 +265,15 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken parameterOverride)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(7, parameterOverride.Children().Count());
+            Assert.That(parameterOverride.Children().Count(), Is.EqualTo(7));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("93f767ed-4d22-45f6-ae97-d1dab0d36e1c",
-                (string) parameterOverride[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) parameterOverride[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParameterOverride", (string) parameterOverride[PropertyNames.ClassKind]);
+            Assert.That((string) parameterOverride[PropertyNames.Iid], Is.EqualTo("93f767ed-4d22-45f6-ae97-d1dab0d36e1c"));
+            Assert.That((int) parameterOverride[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) parameterOverride[PropertyNames.ClassKind], Is.EqualTo("ParameterOverride"));
 
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) parameterOverride[PropertyNames.Owner]);
-            Assert.AreEqual("6c5aff74-f983-4aa8-a9d6-293b3429307c",
-                (string) parameterOverride[PropertyNames.Parameter]);
+            Assert.That((string) parameterOverride[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
+            Assert.That((string) parameterOverride[PropertyNames.Parameter], Is.EqualTo("6c5aff74-f983-4aa8-a9d6-293b3429307c"));
             
             var expectedParameterSubscriptions = new string[] {};
             var parameterSubscriptionsArray = (JArray) parameterOverride[PropertyNames.ParameterSubscription];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParameterOverrideValueSet/ParameterOverrideValueSetTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParameterOverrideValueSet/ParameterOverrideValueSetTestFixture.cs
@@ -64,7 +64,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(parameterOverrideValueSetUri);
 
             //check if there are 6 objects
-            Assert.AreEqual(6, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(6));
 
             // get a specific Iteration from the result by it's unique id
             var iteration = jArray.Single(x => (string)x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
@@ -95,24 +95,23 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken parameterOverrideValueSet)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(10, parameterOverrideValueSet.Children().Count());
+            Assert.That(parameterOverrideValueSet.Children().Count(), Is.EqualTo(10));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("985db346-a297-4ce6-956b-e675d53d415e",
-                (string)parameterOverrideValueSet[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int)parameterOverrideValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParameterOverrideValueSet", (string)parameterOverrideValueSet[PropertyNames.ClassKind]);
+            Assert.That((string)parameterOverrideValueSet[PropertyNames.Iid], Is.EqualTo("985db346-a297-4ce6-956b-e675d53d415e"));
+            Assert.That((int)parameterOverrideValueSet[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string)parameterOverrideValueSet[PropertyNames.ClassKind], Is.EqualTo("ParameterOverrideValueSet"));
 
-            Assert.AreEqual("MANUAL", (string)parameterOverrideValueSet[PropertyNames.ValueSwitch]);
+            Assert.That((string)parameterOverrideValueSet[PropertyNames.ValueSwitch], Is.EqualTo("MANUAL"));
 
             const string emptyProperty = "[\"-\"]";
-            Assert.AreEqual(emptyProperty, (string)parameterOverrideValueSet[PropertyNames.Published]);
-            Assert.AreEqual(emptyProperty, (string)parameterOverrideValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(emptyProperty, (string)parameterOverrideValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(emptyProperty, (string)parameterOverrideValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(emptyProperty, (string)parameterOverrideValueSet[PropertyNames.Reference]);
+            Assert.That((string)parameterOverrideValueSet[PropertyNames.Published], Is.EqualTo(emptyProperty));
+            Assert.That((string)parameterOverrideValueSet[PropertyNames.Formula], Is.EqualTo(emptyProperty));
+            Assert.That((string)parameterOverrideValueSet[PropertyNames.Computed], Is.EqualTo(emptyProperty));
+            Assert.That((string)parameterOverrideValueSet[PropertyNames.Manual], Is.EqualTo(emptyProperty));
+            Assert.That((string)parameterOverrideValueSet[PropertyNames.Reference], Is.EqualTo(emptyProperty));
 
-            Assert.AreEqual("af5c88c6-301f-497b-81f7-53748c3900ed", (string)parameterOverrideValueSet[PropertyNames.ParameterValueSet]);
+            Assert.That((string)parameterOverrideValueSet[PropertyNames.ParameterValueSet], Is.EqualTo("af5c88c6-301f-497b-81f7-53748c3900ed"));
         }
 
         [Test]

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParameterSubscriptionValueSet/ParameterSubscriptionValueSetTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParameterSubscriptionValueSet/ParameterSubscriptionValueSetTestFixture.cs
@@ -63,7 +63,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(parameterSubscriptionValueSetUri);
 
             //check if there are 6 objects
-            Assert.AreEqual(6, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(6));
 
             // get a specific Iteration from the result by it's unique id
             var iteration = jArray.Single(x => (string) x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
@@ -95,22 +95,19 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken parameterSubscriptionValueSet)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(6, parameterSubscriptionValueSet.Children().Count());
+            Assert.That(parameterSubscriptionValueSet.Children().Count(), Is.EqualTo(6));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("a179af79-fd09-44c8-a8a6-3c4c602c7dbf",
-                (string) parameterSubscriptionValueSet[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) parameterSubscriptionValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParameterSubscriptionValueSet",
-                (string) parameterSubscriptionValueSet[PropertyNames.ClassKind]);
+            Assert.That((string) parameterSubscriptionValueSet[PropertyNames.Iid], Is.EqualTo("a179af79-fd09-44c8-a8a6-3c4c602c7dbf"));
+            Assert.That((int) parameterSubscriptionValueSet[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) parameterSubscriptionValueSet[PropertyNames.ClassKind], Is.EqualTo("ParameterSubscriptionValueSet"));
 
-            Assert.AreEqual("af5c88c6-301f-497b-81f7-53748c3900ed",
-                (string) parameterSubscriptionValueSet[PropertyNames.SubscribedValueSet]);
+            Assert.That((string) parameterSubscriptionValueSet[PropertyNames.SubscribedValueSet], Is.EqualTo("af5c88c6-301f-497b-81f7-53748c3900ed"));
 
             const string emptyProperty = "[\"-\"]";
-            Assert.AreEqual(emptyProperty, (string) parameterSubscriptionValueSet[PropertyNames.Manual]);
+            Assert.That((string) parameterSubscriptionValueSet[PropertyNames.Manual], Is.EqualTo(emptyProperty));
 
-            Assert.AreEqual("MANUAL", (string) parameterSubscriptionValueSet[PropertyNames.ValueSwitch]);
+            Assert.That((string) parameterSubscriptionValueSet[PropertyNames.ValueSwitch], Is.EqualTo("MANUAL"));
         }
 
         [Test]

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParameterValueSet/ParameterValueSetTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParameterValueSet/ParameterValueSetTestFixture.cs
@@ -62,7 +62,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(parameterValueSetUri);
 
             // check if there are 5 objects
-            Assert.AreEqual(5, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(5));
 
             // get a specific Iteration from the result by it's unique id
             var iteration = jArray.Single(x => (string)x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
@@ -103,11 +103,11 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             var engineeringModel = jArray.Single(x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int)engineeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int)engineeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // get a specific ElementDefinition from the result by it's unique id
             var elementDefinition = jArray.Single(x => (string)x[PropertyNames.Iid] == "f73860b2-12f0-43e4-b8b2-c81862c0a159");
-            Assert.AreEqual(2, (int)elementDefinition[PropertyNames.RevisionNumber]);
+            Assert.That((int)elementDefinition[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedParameters = new[]
                                          {
@@ -121,29 +121,27 @@ namespace WebservicesIntegrationTests
 
             // get a specific Parameter from the result by it's unique id
             var parameter = jArray.Single(x => (string)x[PropertyNames.Iid] == "2cd4eb9c-e92c-41b2-968c-f03ff7010bad");
-            Assert.AreEqual(2, (int)parameter[PropertyNames.RevisionNumber]);
+            Assert.That((int)parameter[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var valueSetsArray = (JArray)parameter[PropertyNames.ValueSet];
             IList<string> valueSets = valueSetsArray.Select(x => (string)x).ToList();
-            Assert.AreEqual(1, valueSets.Count);
+            Assert.That(valueSets.Count, Is.EqualTo(1));
 
             var parameterValueSet = jArray.Single(x => (string)x[PropertyNames.Iid] == valueSets[0]);
-            Assert.AreEqual(2, (int)parameter[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParameterValueSet", (string)parameterValueSet[PropertyNames.ClassKind]);
+            Assert.That((int)parameter[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string)parameterValueSet[PropertyNames.ClassKind], Is.EqualTo("ParameterValueSet"));
 
-            Assert.AreEqual("MANUAL", (string)parameterValueSet[PropertyNames.ValueSwitch]);
+            Assert.That((string)parameterValueSet[PropertyNames.ValueSwitch], Is.EqualTo("MANUAL"));
 
             const string EmptyProperty = "[\"-\"]";
-            Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Published]);
-            Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Reference]);
+            Assert.That((string)parameterValueSet[PropertyNames.Published], Is.EqualTo(EmptyProperty));
+            Assert.That((string)parameterValueSet[PropertyNames.Formula], Is.EqualTo(EmptyProperty));
+            Assert.That((string)parameterValueSet[PropertyNames.Computed], Is.EqualTo(EmptyProperty));
+            Assert.That((string)parameterValueSet[PropertyNames.Manual], Is.EqualTo(EmptyProperty));
+            Assert.That((string)parameterValueSet[PropertyNames.Reference], Is.EqualTo(EmptyProperty));
 
-            Assert.AreEqual(
-                "b91bfdbb-4277-4a03-b519-e4db839ef5d4",
-                (string)parameterValueSet[PropertyNames.ActualState]);
-            Assert.IsNull((string)parameterValueSet[PropertyNames.ActualOption]);
+            Assert.That((string)parameterValueSet[PropertyNames.ActualState], Is.EqualTo("b91bfdbb-4277-4a03-b519-e4db839ef5d4"));
+            Assert.That((string)parameterValueSet[PropertyNames.ActualOption], Is.Null);
 
             // POST PossibleFiniteState and check what is returned
             postBodyPath = this.GetPath("Tests/EngineeringModel/ParameterValueSet/PostNewPossibleFiniteState.json");
@@ -153,16 +151,16 @@ namespace WebservicesIntegrationTests
 
             engineeringModel =
                 jArray.Single(x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(3, (int)engineeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int)engineeringModel[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             // get a specific ActualFiniteStateList from the result by it's unique id
             var actualFiniteStateList =
                 jArray.Single(x => (string)x[PropertyNames.Iid] == "db690d7d-761c-47fd-96d3-840d698a89dc");
-            Assert.AreEqual(3, (int)actualFiniteStateList[PropertyNames.RevisionNumber]);
+            Assert.That((int)actualFiniteStateList[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             var actualStatesArray = (JArray)actualFiniteStateList[PropertyNames.ActualState];
             IList<string> actualStates = actualStatesArray.Select(x => (string)x).ToList();
-            Assert.AreEqual(2, actualStates.Count);
+            Assert.That(actualStates.Count, Is.EqualTo(2));
 
             var expectedPossibleStates = new List<string> { "b8fdfac4-1c40-475a-ac6c-968654b689b6", "b8fdfac4-1c40-475a-ac6c-968654b689b7" };
 
@@ -170,15 +168,15 @@ namespace WebservicesIntegrationTests
             {
                 // get an ActualFiniteState from the result by it's unique id for existed PossibleFiniteState
                 var actualFiniteState = jArray.Single(x => (string)x[PropertyNames.Iid] == actualState);
-                Assert.AreEqual(3, (int)actualFiniteState[PropertyNames.RevisionNumber]);
+                Assert.That((int)actualFiniteState[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
-                Assert.AreEqual(3, (int)actualFiniteState[PropertyNames.RevisionNumber]);
-                Assert.AreEqual("ActualFiniteState", (string)actualFiniteState[PropertyNames.ClassKind]);
-                Assert.AreEqual("MANDATORY", (string)actualFiniteState[PropertyNames.Kind]);
+                Assert.That((int)actualFiniteState[PropertyNames.RevisionNumber], Is.EqualTo(3));
+                Assert.That((string)actualFiniteState[PropertyNames.ClassKind], Is.EqualTo("ActualFiniteState"));
+                Assert.That((string)actualFiniteState[PropertyNames.Kind], Is.EqualTo("MANDATORY"));
 
                 var possibleStateArray = (JArray)actualFiniteState[PropertyNames.PossibleState];
                 IList<string> possibleStates = possibleStateArray.Select(x => (string)x).ToList();
-                Assert.AreEqual(possibleStates.Count, 1);
+                Assert.That(1, Is.EqualTo(possibleStates.Count));
 
                 var possibleState = possibleStates.First();
                 CollectionAssert.Contains(expectedPossibleStates, possibleState);
@@ -192,7 +190,7 @@ namespace WebservicesIntegrationTests
             // get a specific PossibleFiniteStateList from the result by it's unique id
             var possibleFiniteStateList =
                 jArray.Single(x => (string)x[PropertyNames.Iid] == "449a5bca-34fd-454a-93f8-a56ac8383fee");
-            Assert.AreEqual(3, (int)possibleFiniteStateList[PropertyNames.RevisionNumber]);
+            Assert.That((int)possibleFiniteStateList[PropertyNames.RevisionNumber], Is.EqualTo(3));
             var expectedPossibleFiniteStates = new List<OrderedItem>
                                                    {
                                                        new OrderedItem(73203278, "b8fdfac4-1c40-475a-ac6c-968654b689b6"),
@@ -206,10 +204,10 @@ namespace WebservicesIntegrationTests
             // get a specific PossibleFiniteState from the result by it's unique id
             var possibleFiniteState =
                 jArray.Single(x => (string)x[PropertyNames.Iid] == "b8fdfac4-1c40-475a-ac6c-968654b689b7");
-            Assert.AreEqual(3, (int)possibleFiniteState[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("PossibleFiniteState", (string)possibleFiniteState[PropertyNames.ClassKind]);
-            Assert.AreEqual("Test PossibleFiniteState", (string)possibleFiniteState[PropertyNames.Name]);
-            Assert.AreEqual("TestPossibleFiniteState", (string)possibleFiniteState[PropertyNames.ShortName]);
+            Assert.That((int)possibleFiniteState[PropertyNames.RevisionNumber], Is.EqualTo(3));
+            Assert.That((string)possibleFiniteState[PropertyNames.ClassKind], Is.EqualTo("PossibleFiniteState"));
+            Assert.That((string)possibleFiniteState[PropertyNames.Name], Is.EqualTo("Test PossibleFiniteState"));
+            Assert.That((string)possibleFiniteState[PropertyNames.ShortName], Is.EqualTo("TestPossibleFiniteState"));
 
             var expectedAliases = new string[] { };
             var aliasesArray = (JArray)possibleFiniteState[PropertyNames.Alias];
@@ -228,31 +226,31 @@ namespace WebservicesIntegrationTests
 
             // get a specific Parameter from the result by it's unique id
             parameter = jArray.Single(x => (string)x[PropertyNames.Iid] == "2cd4eb9c-e92c-41b2-968c-f03ff7010bad");
-            Assert.AreEqual(3, (int)parameter[PropertyNames.RevisionNumber]);
+            Assert.That((int)parameter[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             valueSetsArray = (JArray)parameter[PropertyNames.ValueSet];
             valueSets = valueSetsArray.Select(x => (string)x).ToList();
-            Assert.AreEqual(2, valueSets.Count);
+            Assert.That(valueSets.Count, Is.EqualTo(2));
 
             var actualStatesCheckList = actualStates.ToList();
 
             foreach (var valueSet in valueSets)
             {
                 parameterValueSet = jArray.Single(x => (string)x[PropertyNames.Iid] == valueSet);
-                Assert.AreEqual(3, (int)parameterValueSet[PropertyNames.RevisionNumber]);
-                Assert.AreEqual("ParameterValueSet", (string)parameterValueSet[PropertyNames.ClassKind]);
+                Assert.That((int)parameterValueSet[PropertyNames.RevisionNumber], Is.EqualTo(3));
+                Assert.That((string)parameterValueSet[PropertyNames.ClassKind], Is.EqualTo("ParameterValueSet"));
 
-                Assert.AreEqual("MANUAL", (string)parameterValueSet[PropertyNames.ValueSwitch]);
-                Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Published]);
-                Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Formula]);
-                Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Computed]);
-                Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Manual]);
-                Assert.AreEqual(EmptyProperty, (string)parameterValueSet[PropertyNames.Reference]);
+                Assert.That((string)parameterValueSet[PropertyNames.ValueSwitch], Is.EqualTo("MANUAL"));
+                Assert.That((string)parameterValueSet[PropertyNames.Published], Is.EqualTo(EmptyProperty));
+                Assert.That((string)parameterValueSet[PropertyNames.Formula], Is.EqualTo(EmptyProperty));
+                Assert.That((string)parameterValueSet[PropertyNames.Computed], Is.EqualTo(EmptyProperty));
+                Assert.That((string)parameterValueSet[PropertyNames.Manual], Is.EqualTo(EmptyProperty));
+                Assert.That((string)parameterValueSet[PropertyNames.Reference], Is.EqualTo(EmptyProperty));
 
                 var actualStatesCheck = (string) parameterValueSet[PropertyNames.ActualState];
                 CollectionAssert.Contains(actualStatesCheckList, actualStatesCheck);
                 actualStatesCheckList.Remove(actualStatesCheck);
-                Assert.IsNull((string)parameterValueSet[PropertyNames.ActualOption]);
+                Assert.That((string)parameterValueSet[PropertyNames.ActualOption], Is.Null);
             }
 
             CollectionAssert.IsEmpty(actualStatesCheckList,
@@ -267,11 +265,11 @@ namespace WebservicesIntegrationTests
 
             engineeringModel =
                 jArray.Single(x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(4, (int)engineeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int)engineeringModel[PropertyNames.RevisionNumber], Is.EqualTo(4));
 
             // get a specific Iteration from the result by it's unique id
             var iteration = jArray.Single(x => (string)x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
-            Assert.AreEqual(4, (int)iteration[PropertyNames.RevisionNumber]);
+            Assert.That((int)iteration[PropertyNames.RevisionNumber], Is.EqualTo(4));
 
             var expectedPossibleFiniteStateLists = new[]
                                                        {
@@ -286,15 +284,13 @@ namespace WebservicesIntegrationTests
             possibleFiniteStateList =
                 jArray.Single(x => (string)x[PropertyNames.Iid] == "dc3e3763-b8ed-4159-acee-d6a0f4de3dba");
 
-            Assert.AreEqual(4, (int)possibleFiniteStateList[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("PossibleFiniteStateList", (string)possibleFiniteStateList[PropertyNames.ClassKind]);
+            Assert.That((int)possibleFiniteStateList[PropertyNames.RevisionNumber], Is.EqualTo(4));
+            Assert.That((string)possibleFiniteStateList[PropertyNames.ClassKind], Is.EqualTo("PossibleFiniteStateList"));
 
-            Assert.AreEqual("PossibleFiniteStateList Test", (string)possibleFiniteStateList[PropertyNames.Name]);
-            Assert.AreEqual("PossibleFiniteStateListTest", (string)possibleFiniteStateList[PropertyNames.ShortName]);
+            Assert.That((string)possibleFiniteStateList[PropertyNames.Name], Is.EqualTo("PossibleFiniteStateList Test"));
+            Assert.That((string)possibleFiniteStateList[PropertyNames.ShortName], Is.EqualTo("PossibleFiniteStateListTest"));
 
-            Assert.AreEqual(
-                "0e92edde-fdff-41db-9b1d-f2e484f12535",
-                (string)possibleFiniteStateList[PropertyNames.Owner]);
+            Assert.That((string)possibleFiniteStateList[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             expectedPossibleFiniteStates = new List<OrderedItem>
                                                {
@@ -305,7 +301,7 @@ namespace WebservicesIntegrationTests
                     possibleFiniteStateList[PropertyNames.PossibleState].ToString());
             Assert.That(possibleFiniteStates, Is.EquivalentTo(expectedPossibleFiniteStates));
 
-            Assert.IsNull((string)possibleFiniteStateList[PropertyNames.DefaultState]);
+            Assert.That((string)possibleFiniteStateList[PropertyNames.DefaultState], Is.Null);
 
             var expectedCategories = new string[] { };
             var categoriesArray = (JArray)possibleFiniteStateList[PropertyNames.Category];
@@ -330,10 +326,10 @@ namespace WebservicesIntegrationTests
             // get a specific PossibleFiniteState from the result by it's unique id
             possibleFiniteState =
                 jArray.Single(x => (string)x[PropertyNames.Iid] == "d9ed3b43-ba45-45d5-ba1b-196703998a01");
-            Assert.AreEqual(4, (int)possibleFiniteState[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("PossibleFiniteState", (string)possibleFiniteState[PropertyNames.ClassKind]);
-            Assert.AreEqual("PossibleFiniteState Test", (string)possibleFiniteState[PropertyNames.Name]);
-            Assert.AreEqual("PossibleFiniteStateTest", (string)possibleFiniteState[PropertyNames.ShortName]);
+            Assert.That((int)possibleFiniteState[PropertyNames.RevisionNumber], Is.EqualTo(4));
+            Assert.That((string)possibleFiniteState[PropertyNames.ClassKind], Is.EqualTo("PossibleFiniteState"));
+            Assert.That((string)possibleFiniteState[PropertyNames.Name], Is.EqualTo("PossibleFiniteState Test"));
+            Assert.That((string)possibleFiniteState[PropertyNames.ShortName], Is.EqualTo("PossibleFiniteStateTest"));
 
             expectedAliases = new string[] { };
             aliasesArray = (JArray)possibleFiniteState[PropertyNames.Alias];
@@ -353,10 +349,10 @@ namespace WebservicesIntegrationTests
             // get a specific ActualFiniteStateList from the result by it's unique id
             actualFiniteStateList =
                 jArray.Single(x => (string)x[PropertyNames.Iid] == "db690d7d-761c-47fd-96d3-840d698a89dc");
-            Assert.AreEqual(4, (int)actualFiniteStateList[PropertyNames.RevisionNumber]);
+            Assert.That((int)actualFiniteStateList[PropertyNames.RevisionNumber], Is.EqualTo(4));
             actualStatesArray = (JArray)actualFiniteStateList[PropertyNames.ActualState];
             actualStates = actualStatesArray.Select(x => (string)x).ToList();
-            Assert.AreEqual(2, actualStates.Count);
+            Assert.That(actualStates.Count, Is.EqualTo(2));
             var expectedPossibleFiniteStateListsInActualFiniteStateList = new List<OrderedItem>
                                                                               {
                                                                                   new OrderedItem(
@@ -373,20 +369,20 @@ namespace WebservicesIntegrationTests
 
             // get a specific ActualFiniteState from the result by it's unique id
             var actualFiniteState0 = jArray.Single(x => (string)x[PropertyNames.Iid] == actualStates[0]);
-            Assert.AreEqual(4, (int)actualFiniteState0[PropertyNames.RevisionNumber]);
+            Assert.That((int)actualFiniteState0[PropertyNames.RevisionNumber], Is.EqualTo(4));
 
             var actualFiniteState1 = jArray.Single(x => (string)x[PropertyNames.Iid] == actualStates[1]);
-            Assert.AreEqual(4, (int)actualFiniteState1[PropertyNames.RevisionNumber]);
+            Assert.That((int)actualFiniteState1[PropertyNames.RevisionNumber], Is.EqualTo(4));
 
             parameterValueSet = jArray.Single(x => (string)x[PropertyNames.ClassKind] == "ParameterValueSet" && (string)x[PropertyNames.ActualState] == actualStates[0]);
-            Assert.AreEqual(4, (int)parameterValueSet[PropertyNames.RevisionNumber]);
+            Assert.That((int)parameterValueSet[PropertyNames.RevisionNumber], Is.EqualTo(4));
 
             parameterValueSet = jArray.Single(x => (string)x[PropertyNames.ClassKind] == "ParameterValueSet" && (string)x[PropertyNames.ActualState] == actualStates[1]);
-            Assert.AreEqual(4, (int)parameterValueSet[PropertyNames.RevisionNumber]);
+            Assert.That((int)parameterValueSet[PropertyNames.RevisionNumber], Is.EqualTo(4));
 
             // get a specific Parameter from the result by it's unique id
             parameter = jArray.Single(x => (string)x[PropertyNames.Iid] == "2cd4eb9c-e92c-41b2-968c-f03ff7010bad");
-            Assert.AreEqual(4, (int)parameter[PropertyNames.RevisionNumber]);
+            Assert.That((int)parameter[PropertyNames.RevisionNumber], Is.EqualTo(4));
         }
 
         /// <summary>
@@ -399,24 +395,24 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken parameterValueSet)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(11, parameterValueSet.Children().Count());
+            Assert.That(parameterValueSet.Children().Count(), Is.EqualTo(11));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("af5c88c6-301f-497b-81f7-53748c3900ed", (string)parameterValueSet[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int)parameterValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParameterValueSet", (string)parameterValueSet[PropertyNames.ClassKind]);
+            Assert.That((string)parameterValueSet[PropertyNames.Iid], Is.EqualTo("af5c88c6-301f-497b-81f7-53748c3900ed"));
+            Assert.That((int)parameterValueSet[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string)parameterValueSet[PropertyNames.ClassKind], Is.EqualTo("ParameterValueSet"));
 
-            Assert.AreEqual("MANUAL", (string)parameterValueSet[PropertyNames.ValueSwitch]);
+            Assert.That((string)parameterValueSet[PropertyNames.ValueSwitch], Is.EqualTo("MANUAL"));
 
             const string emptyProperty = "[\"-\"]";
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Published]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Formula]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Computed]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Manual]);
-            Assert.AreEqual(emptyProperty, (string)parameterValueSet[PropertyNames.Reference]);
+            Assert.That((string)parameterValueSet[PropertyNames.Published], Is.EqualTo(emptyProperty));
+            Assert.That((string)parameterValueSet[PropertyNames.Formula], Is.EqualTo(emptyProperty));
+            Assert.That((string)parameterValueSet[PropertyNames.Computed], Is.EqualTo(emptyProperty));
+            Assert.That((string)parameterValueSet[PropertyNames.Manual], Is.EqualTo(emptyProperty));
+            Assert.That((string)parameterValueSet[PropertyNames.Reference], Is.EqualTo(emptyProperty));
 
-            Assert.IsNull((string)parameterValueSet[PropertyNames.ActualState]);
-            Assert.IsNull((string)parameterValueSet[PropertyNames.ActualOption]);
+            Assert.That((string)parameterValueSet[PropertyNames.ActualState], Is.Null);
+            Assert.That((string)parameterValueSet[PropertyNames.ActualOption], Is.Null);
         }
 
         [Test]
@@ -431,11 +427,11 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             var engineeeringModel = jArray.Single(x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int)engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int)engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var parameterValueSet = jArray.Single(x => (string)x[PropertyNames.Iid] == "72ec3701-bcb5-4bf6-bd78-30fd1b65e3be");
 
-            Assert.AreEqual("72ec3701-bcb5-4bf6-bd78-30fd1b65e3be", (string)parameterValueSet[PropertyNames.Iid]);
+            Assert.That((string)parameterValueSet[PropertyNames.Iid], Is.EqualTo("72ec3701-bcb5-4bf6-bd78-30fd1b65e3be"));
         }
 
         [Test]
@@ -453,11 +449,11 @@ namespace WebservicesIntegrationTests
 
             var parameterValueSet = jArray.Single(x => (string)x[PropertyNames.Iid] == "72ec3701-bcb5-4bf6-bd78-30fd1b65e3be");
 
-            Assert.AreEqual(inputValue, JsonConvert.DeserializeObject<List<string>>((string)parameterValueSet[PropertyNames.Formula])[0]);
-            Assert.AreEqual(inputValue, JsonConvert.DeserializeObject<List<string>>((string)parameterValueSet[PropertyNames.Published])[0]);
-            Assert.AreEqual(inputValue, JsonConvert.DeserializeObject<List<string>>((string)parameterValueSet[PropertyNames.Computed])[0]);
-            Assert.AreEqual(inputValue, JsonConvert.DeserializeObject<List<string>>((string)parameterValueSet[PropertyNames.Manual])[0]);
-            Assert.AreEqual(inputValue, JsonConvert.DeserializeObject<List<string>>((string)parameterValueSet[PropertyNames.Reference])[0]);
+            Assert.That(JsonConvert.DeserializeObject<List<string>>((string)parameterValueSet[PropertyNames.Formula])[0], Is.EqualTo(inputValue));
+            Assert.That(JsonConvert.DeserializeObject<List<string>>((string)parameterValueSet[PropertyNames.Published])[0], Is.EqualTo(inputValue));
+            Assert.That(JsonConvert.DeserializeObject<List<string>>((string)parameterValueSet[PropertyNames.Computed])[0], Is.EqualTo(inputValue));
+            Assert.That(JsonConvert.DeserializeObject<List<string>>((string)parameterValueSet[PropertyNames.Manual])[0], Is.EqualTo(inputValue));
+            Assert.That(JsonConvert.DeserializeObject<List<string>>((string)parameterValueSet[PropertyNames.Reference])[0], Is.EqualTo(inputValue));
         }
 
         [Test]
@@ -472,17 +468,17 @@ namespace WebservicesIntegrationTests
             postBody = postBody.Replace("<INNERJSON>", inputAsInnerJson);
 
             var jArray1 = this.WebClient.PostDto(iterationUri, postBody);
-            Assert.AreEqual(3, jArray1.Count);
+            Assert.That(jArray1.Count, Is.EqualTo(3));
 
             var parameterValueSetUri1 = new Uri($"{this.Settings.Hostname}/EngineeringModel/9ec982e4-ef72-4953-aa85-b158a95d8d56/iteration/e163c5ad-f32b-4387-b805-f4b34600bc2c/element/f73860b2-12f0-43e4-b8b2-c81862c0a159/parameter/3f05483f-66ff-4f21-bc76-45956779f66e/valueSet/72ec3701-bcb5-4bf6-bd78-30fd1b65e3be?revisionFrom=1&revisionTo=2");
 
             var jArray2 = this.WebClient.GetDto(parameterValueSetUri1);
-            Assert.AreEqual(2, jArray2.Count);
+            Assert.That(jArray2.Count, Is.EqualTo(2));
 
             var parameterValueSetUri2 = new Uri($"{this.Settings.Hostname}/EngineeringModel/9ec982e4-ef72-4953-aa85-b158a95d8d56/iteration/e163c5ad-f32b-4387-b805-f4b34600bc2c/element/f73860b2-12f0-43e4-b8b2-c81862c0a159/parameter/3f05483f-66ff-4f21-bc76-45956779f66e/valueSet/72ec3701-bcb5-4bf6-bd78-30fd1b65e3be?revisionFrom=2000-01-01T12:00:00&revisionTo=2120-12-31T12:00:00");
 
             var jArray3 = this.WebClient.GetDto(parameterValueSetUri2);
-            Assert.AreEqual(2, jArray3.Count);
+            Assert.That(jArray3.Count, Is.EqualTo(2));
         }
 
         [Test]

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParametricConstraint/ParametricConstraintTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/ParametricConstraint/ParametricConstraintTestFixture.cs
@@ -62,7 +62,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(parametricConstraintUri);
 
             // verify that the correct amount of objects is returned
-            Assert.AreEqual(5, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(5));
 
             // get a specific Iteration from the result by it's unique id
             var iteration = jArray.Single(x => (string) x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
@@ -94,17 +94,17 @@ namespace WebservicesIntegrationTests
             Assert.That(jArray.Count, Is.EqualTo(4));
 
             var engineeringModel = jArray.Single(x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int) engineeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var relationalExpression = jArray.Single(x => (string) x[PropertyNames.Iid] == "d8a88095-a51f-4b3a-8746-97659f313143");
-            Assert.AreEqual(2, (int) relationalExpression[PropertyNames.RevisionNumber]);
+            Assert.That((int) relationalExpression[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var requirement = jArray.Single(x => (string) x[PropertyNames.Iid] == "614e2a69-d602-46be-9311-2fb4d3273e87");
-            Assert.AreEqual(2, (int) requirement[PropertyNames.RevisionNumber]);
+            Assert.That((int) requirement[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var parametricConstraint = jArray.Single(x => (string) x[PropertyNames.Iid] == "5e1ad29c-ac18-474d-832c-5f2d0d203176");
-            Assert.AreEqual(5, parametricConstraint.Children().Count());
-            Assert.AreEqual(2, (int) parametricConstraint[PropertyNames.RevisionNumber]);
+            Assert.That(parametricConstraint.Children().Count(), Is.EqualTo(5));
+            Assert.That((int) parametricConstraint[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedConstraints = new List<OrderedItem> { new OrderedItem(1, "88200dbc-711a-47e0-a54a-dac4baca6e83"), new OrderedItem(2, "5e1ad29c-ac18-474d-832c-5f2d0d203176") };
             var constraintArray = JsonConvert.DeserializeObject<List<OrderedItem>>(requirement[PropertyNames.ParametricConstraint].ToString());
@@ -117,16 +117,16 @@ namespace WebservicesIntegrationTests
             Assert.That(jArray.Count, Is.EqualTo(4));
 
             engineeringModel = jArray.Single(x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(3, (int) engineeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeringModel[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             var constraint1 = jArray.Single(x => (string) x[PropertyNames.Iid] == "5e1ad29c-ac18-474d-832c-5f2d0d203176");
-            Assert.AreEqual(3, (int) constraint1[PropertyNames.RevisionNumber]);
+            Assert.That((int) constraint1[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             var constraint2 = jArray.Single(x => (string) x[PropertyNames.Iid] == "88200dbc-711a-47e0-a54a-dac4baca6e83");
-            Assert.AreEqual(3, (int) constraint2[PropertyNames.RevisionNumber]);
+            Assert.That((int) constraint2[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             requirement = jArray.Single(x => (string) x[PropertyNames.Iid] == "614e2a69-d602-46be-9311-2fb4d3273e87");
-            Assert.AreEqual(3, (int) requirement[PropertyNames.RevisionNumber]);
+            Assert.That((int) requirement[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             expectedConstraints = new List<OrderedItem> { new OrderedItem(3, "5e1ad29c-ac18-474d-832c-5f2d0d203176"), new OrderedItem(4, "88200dbc-711a-47e0-a54a-dac4baca6e83") };
             constraintArray = JsonConvert.DeserializeObject<List<OrderedItem>>(requirement[PropertyNames.ParametricConstraint].ToString());
@@ -143,15 +143,14 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken parametricConstraint)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(5, parametricConstraint.Children().Count());
+            Assert.That(parametricConstraint.Children().Count(), Is.EqualTo(5));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("88200dbc-711a-47e0-a54a-dac4baca6e83", (string) parametricConstraint[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) parametricConstraint[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ParametricConstraint", (string) parametricConstraint[PropertyNames.ClassKind]);
+            Assert.That((string) parametricConstraint[PropertyNames.Iid], Is.EqualTo("88200dbc-711a-47e0-a54a-dac4baca6e83"));
+            Assert.That((int) parametricConstraint[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) parametricConstraint[PropertyNames.ClassKind], Is.EqualTo("ParametricConstraint"));
 
-            Assert.AreEqual("30cb785a-9e72-477f-ad1a-8df6ab623e3d",
-                (string) parametricConstraint[PropertyNames.TopExpression]);
+            Assert.That((string) parametricConstraint[PropertyNames.TopExpression], Is.EqualTo("30cb785a-9e72-477f-ad1a-8df6ab623e3d"));
 
             var expectedExpressions = new string[]
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/PossibleFiniteState/PossibleFiniteStateTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/PossibleFiniteState/PossibleFiniteStateTestFixture.cs
@@ -99,14 +99,14 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken possibleFiniteState)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(8, possibleFiniteState.Children().Count());
+            Assert.That(possibleFiniteState.Children().Count(), Is.EqualTo(8));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("b8fdfac4-1c40-475a-ac6c-968654b689b6", (string)possibleFiniteState[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int)possibleFiniteState[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("PossibleFiniteState", (string)possibleFiniteState[PropertyNames.ClassKind]);
-            Assert.AreEqual("Test Possible Finite State", (string)possibleFiniteState[PropertyNames.Name]);
-            Assert.AreEqual("TestPossibleFiniteState", (string)possibleFiniteState[PropertyNames.ShortName]);
+            Assert.That((string)possibleFiniteState[PropertyNames.Iid], Is.EqualTo("b8fdfac4-1c40-475a-ac6c-968654b689b6"));
+            Assert.That((int)possibleFiniteState[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string)possibleFiniteState[PropertyNames.ClassKind], Is.EqualTo("PossibleFiniteState"));
+            Assert.That((string)possibleFiniteState[PropertyNames.Name], Is.EqualTo("Test Possible Finite State"));
+            Assert.That((string)possibleFiniteState[PropertyNames.ShortName], Is.EqualTo("TestPossibleFiniteState"));
 
             var expectedAliases = new string[] { };
             var aliasesArray = (JArray)possibleFiniteState[PropertyNames.Alias];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/PossibleFiniteStateList/PossibleFiniteStateListTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/PossibleFiniteStateList/PossibleFiniteStateListTestFixture.cs
@@ -84,17 +84,17 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken possibleFiniteStateList)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(12, possibleFiniteStateList.Children().Count());
+            Assert.That(possibleFiniteStateList.Children().Count(), Is.EqualTo(12));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("449a5bca-34fd-454a-93f8-a56ac8383fee", (string)possibleFiniteStateList[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int)possibleFiniteStateList[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("PossibleFiniteStateList", (string)possibleFiniteStateList[PropertyNames.ClassKind]);
+            Assert.That((string)possibleFiniteStateList[PropertyNames.Iid], Is.EqualTo("449a5bca-34fd-454a-93f8-a56ac8383fee"));
+            Assert.That((int)possibleFiniteStateList[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string)possibleFiniteStateList[PropertyNames.ClassKind], Is.EqualTo("PossibleFiniteStateList"));
 
-            Assert.AreEqual("Test Possible FiniteState List", (string)possibleFiniteStateList[PropertyNames.Name]);
-            Assert.AreEqual("TestPossibleFiniteStateList", (string)possibleFiniteStateList[PropertyNames.ShortName]);
+            Assert.That((string)possibleFiniteStateList[PropertyNames.Name], Is.EqualTo("Test Possible FiniteState List"));
+            Assert.That((string)possibleFiniteStateList[PropertyNames.ShortName], Is.EqualTo("TestPossibleFiniteStateList"));
 
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string)possibleFiniteStateList[PropertyNames.Owner]);
+            Assert.That((string)possibleFiniteStateList[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             var expectedPossibleFiniteStates = new List<OrderedItem>
             {
@@ -104,7 +104,7 @@ namespace WebservicesIntegrationTests
                 possibleFiniteStateList[PropertyNames.PossibleState].ToString());
             Assert.That(possibleFiniteStates, Is.EquivalentTo(expectedPossibleFiniteStates));
 
-            Assert.AreEqual("b8fdfac4-1c40-475a-ac6c-968654b689b6", (string)possibleFiniteStateList[PropertyNames.DefaultState]);
+            Assert.That((string)possibleFiniteStateList[PropertyNames.DefaultState], Is.EqualTo("b8fdfac4-1c40-475a-ac6c-968654b689b6"));
 
             var expectedCategories = new string[] { };
             var categoriesArray = (JArray)possibleFiniteStateList[PropertyNames.Category];
@@ -136,7 +136,7 @@ namespace WebservicesIntegrationTests
             var postBody1 = this.GetJsonFromFile(postBodyPath1);
 
             var jArray1 = this.WebClient.PostDto(uri, postBody1);
-            Assert.AreEqual(6, jArray1.Count);
+            Assert.That(jArray1.Count, Is.EqualTo(6));
 
             var postBodyPath2 = this.GetPath("Tests/EngineeringModel/PossibleFiniteStateList/PostDeletePossibleFiniteStateAsProperty.json");
 
@@ -154,14 +154,14 @@ namespace WebservicesIntegrationTests
             var postBodyPath1 = this.GetPath("Tests/EngineeringModel/PossibleFiniteStateList/PostCreatePossibleFiniteStateListContainingTwoStates.json");
             var postBody1 = this.GetJsonFromFile(postBodyPath1);
             var jArray1 = this.WebClient.PostDto(uri, postBody1);
-            Assert.AreEqual(5, jArray1.Count);
+            Assert.That(jArray1.Count, Is.EqualTo(5));
 
             uri = new Uri($"{this.Settings.Hostname}/EngineeringModel/9ec982e4-ef72-4953-aa85-b158a95d8d56/iteration/e163c5ad-f32b-4387-b805-f4b34600bc2c");
             postBodyPath1 = this.GetPath("Tests/EngineeringModel/PossibleFiniteStateList/PostCreatePossibleFiniteStateForWrongReorder.json");
             postBody1 = this.GetJsonFromFile(postBodyPath1);
 
             jArray1 = this.WebClient.PostDto(uri, postBody1);
-            Assert.AreEqual(3, jArray1.Count);
+            Assert.That(jArray1.Count, Is.EqualTo(3));
 
             var postBodyPath2 = this.GetPath("Tests/EngineeringModel/PossibleFiniteStateList/PostReorderStatesOfPossibleFiniteStateListWrong.json");
 
@@ -185,7 +185,7 @@ namespace WebservicesIntegrationTests
 
             var jArray1 = this.WebClient.PostDto(uri, postBody1);
             
-            Assert.AreEqual(6, jArray1.Count);
+            Assert.That(jArray1.Count, Is.EqualTo(6));
 
             var postBodyPath2 = this.GetPath("Tests/EngineeringModel/PossibleFiniteStateList/PostDeletePossibleFiniteState.json");
 
@@ -203,8 +203,8 @@ namespace WebservicesIntegrationTests
             var afsl = jArray.Single(x => x["classKind"].ToString() == "ActualFiniteStateList");
             var afs = jArray.Single(x => x["classKind"].ToString() == "ActualFiniteState");
 
-            Assert.AreEqual("9ec982e4-ef72-4953-aa85-b158a95d8d56", model["iid"].ToString());
-            Assert.AreEqual("449a5bca-34fd-454a-93f8-a56ac8383fee", pfsl["iid"].ToString());
+            Assert.That(model["iid"].ToString(), Is.EqualTo("9ec982e4-ef72-4953-aa85-b158a95d8d56"));
+            Assert.That(pfsl["iid"].ToString(), Is.EqualTo("449a5bca-34fd-454a-93f8-a56ac8383fee"));
         }
 
         [Test]
@@ -216,7 +216,7 @@ namespace WebservicesIntegrationTests
             var postBodyPath1 = this.GetPath("Tests/EngineeringModel/PossibleFiniteStateList/PostCreatePossibleFiniteStateListContainingTwoStates.json");
             var postBody1 = this.GetJsonFromFile(postBodyPath1);
             var jArray1 = this.WebClient.PostDto(uri, postBody1);
-            Assert.AreEqual(5, jArray1.Count);
+            Assert.That(jArray1.Count, Is.EqualTo(5));
 
             var postBodyPath2 = this.GetPath("Tests/EngineeringModel/PossibleFiniteStateList/PostReorderStatesOfPossibleFiniteStateList.json");
             var postBody2 = this.GetJsonFromFile(postBodyPath2);
@@ -227,20 +227,20 @@ namespace WebservicesIntegrationTests
             var possibleFiniteStateList = jArray2.Where(x => x["classKind"].ToString() == "PossibleFiniteStateList").ToList();
             var possibleFiniteStates = jArray2.Where(x => x["classKind"].ToString() == "PossibleFiniteState").ToList();
 
-            Assert.AreEqual(engineeringModel.Count, 1);
-            Assert.AreEqual(possibleFiniteStateList.Count, 1);
-            Assert.AreEqual(possibleFiniteStates.Count, 2);
+            Assert.That(1, Is.EqualTo(engineeringModel.Count));
+            Assert.That(1, Is.EqualTo(possibleFiniteStateList.Count));
+            Assert.That(2, Is.EqualTo(possibleFiniteStates.Count));
 
-            Assert.AreEqual(possibleFiniteStateList.First()["possibleState"].Count(), 2);
+            Assert.That(2, Is.EqualTo(possibleFiniteStateList.First()["possibleState"].Count()));
 
             var firstPossibleState = possibleFiniteStateList.First()["possibleState"].First();
             var secondPossibleState = possibleFiniteStateList.First()["possibleState"].Last();
 
-            Assert.AreEqual((int)firstPossibleState["k"], 13512213);
-            Assert.AreEqual((string)firstPossibleState["v"], "8ca48538-d39d-4b09-8944-77c34535ce7a");
+            Assert.That(13512213, Is.EqualTo((int)firstPossibleState["k"]));
+            Assert.That("8ca48538-d39d-4b09-8944-77c34535ce7a", Is.EqualTo((string)firstPossibleState["v"]));
 
-            Assert.AreEqual((int)secondPossibleState["k"], 125842400);
-            Assert.AreEqual((string)secondPossibleState["v"], "a6f9789d-26a7-45e6-a528-3cbd1fce3880");
+            Assert.That(125842400, Is.EqualTo((int)secondPossibleState["k"]));
+            Assert.That("a6f9789d-26a7-45e6-a528-3cbd1fce3880", Is.EqualTo((string)secondPossibleState["v"]));
 
         }
     }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Publication/PublicationTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Publication/PublicationTestFixture.cs
@@ -84,13 +84,13 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             var engineeeringModel = jArray.Single(x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int)engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int)engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // get a specific ParameterValueSet from the result by it's unique id
             var parameterValueSet = jArray.Single(x => (string)x[PropertyNames.Iid] == "72ec3701-bcb5-4bf6-bd78-30fd1b65e3be");
 
-            Assert.AreEqual(2, (int)parameterValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("[\"test\"]", (string)parameterValueSet[PropertyNames.Manual]);
+            Assert.That((int)parameterValueSet[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string)parameterValueSet[PropertyNames.Manual], Is.EqualTo("[\"test\"]"));
 
             postBodyPath = this.GetPath("Tests/EngineeringModel/Publication/PostNewPublication.json");
 
@@ -98,11 +98,11 @@ namespace WebservicesIntegrationTests
             jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             engineeeringModel = jArray.Single(x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(3, (int)engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int)engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             // get a specific Iteration from the result by it's unique id
             var iteration = jArray.Single(x => (string)x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
-            Assert.AreEqual(3, (int)iteration[PropertyNames.RevisionNumber]);
+            Assert.That((int)iteration[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             var expectedPublications = new string[]
                                            {
@@ -114,14 +114,14 @@ namespace WebservicesIntegrationTests
             Assert.That(publications, Is.EquivalentTo(expectedPublications));
 
             parameterValueSet = jArray.Single(x => (string)x[PropertyNames.Iid] == "72ec3701-bcb5-4bf6-bd78-30fd1b65e3be");
-            Assert.AreEqual(3, (int)parameterValueSet[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("[\"test\"]", (string)parameterValueSet[PropertyNames.Published]);
+            Assert.That((int)parameterValueSet[PropertyNames.RevisionNumber], Is.EqualTo(3));
+            Assert.That((string)parameterValueSet[PropertyNames.Published], Is.EqualTo("[\"test\"]"));
 
             // get a specific Publication from the result by it's unique id
             var publication = jArray.Single(x => (string)x[PropertyNames.Iid] == "aec92178-186c-40d5-b23a-78f0423906f6");
 
-            Assert.AreEqual(3, (int)publication[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("Publication", (string)publication[PropertyNames.ClassKind]);
+            Assert.That((int)publication[PropertyNames.RevisionNumber], Is.EqualTo(3));
+            Assert.That((string)publication[PropertyNames.ClassKind], Is.EqualTo("Publication"));
 
             var expectedDomains = new string[]
                                       {
@@ -151,14 +151,14 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken publication)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(6, publication.Children().Count());
+            Assert.That(publication.Children().Count(), Is.EqualTo(6));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("790b9e60-476b-4b6d-8aba-0af15178535e", (string) publication[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) publication[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("Publication", (string) publication[PropertyNames.ClassKind]);
+            Assert.That((string) publication[PropertyNames.Iid], Is.EqualTo("790b9e60-476b-4b6d-8aba-0af15178535e"));
+            Assert.That((int) publication[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) publication[PropertyNames.ClassKind], Is.EqualTo("Publication"));
 
-            Assert.AreEqual("2016-10-25T09:00:35.936Z", (string) publication[PropertyNames.CreatedOn]);
+            Assert.That((string) publication[PropertyNames.CreatedOn], Is.EqualTo("2016-10-25T09:00:35.936Z"));
 
             var expectedDomains = new string[] {};
             var domainsArray = (JArray) publication[PropertyNames.Domain];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/RelationalExpression/RelationalExpressionTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/RelationalExpression/RelationalExpressionTestFixture.cs
@@ -41,7 +41,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(relationalExpressionUri);
 
             //check if there are the correct amount of objects 
-            Assert.AreEqual(6, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(6));
 
             RelationalExpressionTestFixture.VerifyProperties(jArray);
         }
@@ -57,7 +57,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(relationalExpressionUri);
 
             // verify that the correct amount of objects is returned
-            Assert.AreEqual(11, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(11));
 
             // get a specific Iteration from the result by it's unique id
             var iteration = jArray.Single(x => (string) x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
@@ -90,30 +90,26 @@ namespace WebservicesIntegrationTests
             var relationalExpressionObject = relationalExpression.Single(x => (string) x[PropertyNames.Iid] == "deaa2560-b704-4b2c-950b-aad02ff84052");
 
             // assert that the properties are what is expected
-            Assert.AreEqual("deaa2560-b704-4b2c-950b-aad02ff84052",
-                (string) relationalExpressionObject[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) relationalExpressionObject[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("RelationalExpression", (string) relationalExpressionObject[PropertyNames.ClassKind]);
+            Assert.That((string) relationalExpressionObject[PropertyNames.Iid], Is.EqualTo("deaa2560-b704-4b2c-950b-aad02ff84052"));
+            Assert.That((int) relationalExpressionObject[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) relationalExpressionObject[PropertyNames.ClassKind], Is.EqualTo("RelationalExpression"));
 
-            Assert.IsNull((string) relationalExpressionObject[PropertyNames.Scale]);
-            Assert.AreEqual("[\"true\"]", (string) relationalExpressionObject[PropertyNames.Value]);
-            Assert.AreEqual("EQ", (string) relationalExpressionObject[PropertyNames.RelationalOperator]);
-            Assert.AreEqual("35a9cf05-4eba-4cda-b60c-7cfeaac8f892",
-                (string) relationalExpressionObject[PropertyNames.ParameterType]);
+            Assert.That((string) relationalExpressionObject[PropertyNames.Scale], Is.Null);
+            Assert.That((string) relationalExpressionObject[PropertyNames.Value], Is.EqualTo("[\"true\"]"));
+            Assert.That((string) relationalExpressionObject[PropertyNames.RelationalOperator], Is.EqualTo("EQ"));
+            Assert.That((string) relationalExpressionObject[PropertyNames.ParameterType], Is.EqualTo("35a9cf05-4eba-4cda-b60c-7cfeaac8f892"));
 
             relationalExpressionObject = relationalExpression.Single(x => (string) x[PropertyNames.Iid] == "a6e44651-7c4a-4a57-bdf9-c0290497f392");
 
             // assert that the properties are what is expected
-            Assert.AreEqual("a6e44651-7c4a-4a57-bdf9-c0290497f392",
-                (string) relationalExpressionObject[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) relationalExpressionObject[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("RelationalExpression", (string) relationalExpressionObject[PropertyNames.ClassKind]);
+            Assert.That((string) relationalExpressionObject[PropertyNames.Iid], Is.EqualTo("a6e44651-7c4a-4a57-bdf9-c0290497f392"));
+            Assert.That((int) relationalExpressionObject[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) relationalExpressionObject[PropertyNames.ClassKind], Is.EqualTo("RelationalExpression"));
 
-            Assert.IsNull((string) relationalExpressionObject[PropertyNames.Scale]);
-            Assert.AreEqual("[\"test\"]", (string) relationalExpressionObject[PropertyNames.Value]);
-            Assert.AreEqual("EQ", (string) relationalExpressionObject[PropertyNames.RelationalOperator]);
-            Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254",
-                (string) relationalExpressionObject[PropertyNames.ParameterType]);
+            Assert.That((string) relationalExpressionObject[PropertyNames.Scale], Is.Null);
+            Assert.That((string) relationalExpressionObject[PropertyNames.Value], Is.EqualTo("[\"test\"]"));
+            Assert.That((string) relationalExpressionObject[PropertyNames.RelationalOperator], Is.EqualTo("EQ"));
+            Assert.That((string) relationalExpressionObject[PropertyNames.ParameterType], Is.EqualTo("a21c15c4-3e1e-46b5-b109-5063dec1e254"));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Requirement/RequirementTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Requirement/RequirementTestFixture.cs
@@ -44,7 +44,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(requirementUri);
 
             // check if there are only two Requirement object 
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             VerifyProperties(jArray);
         }
@@ -60,7 +60,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(requirementUri);
 
             // verify that the correct amount of objects is returned
-            Assert.AreEqual(5, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(5));
 
             // get a specific Iteration from the result by it's unique id
             var iteration = jArray.Single(x => (string) x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
@@ -84,11 +84,11 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             var engineeeringModel = jArray.Single(x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // get a specific RequirementsSpecification from the result by it's unique id
             var requirementsSpecification = jArray.Single(x => (string) x[PropertyNames.Iid] == "bf0cde90-9086-43d5-bcff-32a2f8331800");
-            Assert.AreEqual(2, (int) requirementsSpecification[PropertyNames.RevisionNumber]);
+            Assert.That((int) requirementsSpecification[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedRequirements = new[]
             {
@@ -104,9 +104,9 @@ namespace WebservicesIntegrationTests
             var requirement = jArray.Single(
                 x => (string) x[PropertyNames.Iid] == "09af5432-b7a5-4932-a983-b1065723efb7");
 
-            Assert.AreEqual(2, (int) requirement[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("create requirement", (string) requirement[PropertyNames.Name]);
-            Assert.AreEqual("createrequirement", (string) requirement[PropertyNames.ShortName]);
+            Assert.That((int) requirement[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) requirement[PropertyNames.Name], Is.EqualTo("create requirement"));
+            Assert.That((string) requirement[PropertyNames.ShortName], Is.EqualTo("createrequirement"));
             Assert.IsFalse((bool) requirement[PropertyNames.IsDeprecated]);
         }
 
@@ -124,10 +124,10 @@ namespace WebservicesIntegrationTests
             Assert.That(jArray.Count, Is.EqualTo(4));
 
             var engineeeringModel = jArray.Single(x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var requirementsSpecificationWithMovedRequirement = jArray.Single(x => (string) x[PropertyNames.Iid] == "8d0734f4-ca4b-4611-9187-f6970e2b02bc");
-            Assert.AreEqual(2, (int) requirementsSpecificationWithMovedRequirement[PropertyNames.RevisionNumber]);
+            Assert.That((int) requirementsSpecificationWithMovedRequirement[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedRequirements = new[] { "614e2a69-d602-46be-9311-2fb4d3273e87" };
             var requirementsArray = (JArray) requirementsSpecificationWithMovedRequirement[PropertyNames.Requirement];
@@ -135,7 +135,7 @@ namespace WebservicesIntegrationTests
             Assert.That(requirements, Is.EquivalentTo(expectedRequirements));
 
             var requirementsSpecificationWithoutMovedRequirement = jArray.Single(x => (string) x[PropertyNames.Iid] == "bf0cde90-9086-43d5-bcff-32a2f8331800");
-            Assert.AreEqual(2, (int) requirementsSpecificationWithoutMovedRequirement[PropertyNames.RevisionNumber]);
+            Assert.That((int) requirementsSpecificationWithoutMovedRequirement[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             expectedRequirements = new string[] { "614e2a69-d602-46be-9311-2fb4d3273e88" };
             requirementsArray = (JArray) requirementsSpecificationWithoutMovedRequirement[PropertyNames.Requirement];
@@ -143,7 +143,7 @@ namespace WebservicesIntegrationTests
             Assert.That(requirements, Is.EquivalentTo(expectedRequirements));
 
             var requirement = jArray.Single(x => (string) x[PropertyNames.Iid] == "614e2a69-d602-46be-9311-2fb4d3273e87");
-            Assert.AreEqual(2, (int) requirement[PropertyNames.RevisionNumber]);
+            Assert.That((int) requirement[PropertyNames.RevisionNumber], Is.EqualTo(2));
         }
 
         [Test]
@@ -157,14 +157,14 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             // check if there are 2 objects
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             var engineeeringModel = jArray.Single(x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // get a specific Requirement from the result by it's unique id
             var requirement = jArray.Single(x => (string) x[PropertyNames.Iid] == "614e2a69-d602-46be-9311-2fb4d3273e87");
-            Assert.AreEqual(2, (int) requirement[PropertyNames.RevisionNumber]);
+            Assert.That((int) requirement[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedParametricConstraints = new List<OrderedItem>();
 
@@ -192,20 +192,20 @@ namespace WebservicesIntegrationTests
                 x => (string) x[PropertyNames.Iid] == "614e2a69-d602-46be-9311-2fb4d3273e87");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(14, requirement.Children().Count());
+            Assert.That(requirement.Children().Count(), Is.EqualTo(14));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("614e2a69-d602-46be-9311-2fb4d3273e87", (string) requirement[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) requirement[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("Requirement", (string) requirement[PropertyNames.ClassKind]);
+            Assert.That((string) requirement[PropertyNames.Iid], Is.EqualTo("614e2a69-d602-46be-9311-2fb4d3273e87"));
+            Assert.That((int) requirement[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) requirement[PropertyNames.ClassKind], Is.EqualTo("Requirement"));
 
-            Assert.AreEqual("Test Requirement", (string) requirement[PropertyNames.Name]);
-            Assert.AreEqual("TestRequirement", (string) requirement[PropertyNames.ShortName]);
+            Assert.That((string) requirement[PropertyNames.Name], Is.EqualTo("Test Requirement"));
+            Assert.That((string) requirement[PropertyNames.ShortName], Is.EqualTo("TestRequirement"));
 
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) requirement[PropertyNames.Owner]);
+            Assert.That((string) requirement[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             Assert.IsFalse((bool) requirement[PropertyNames.IsDeprecated]);
-            Assert.IsNull((string) requirement[PropertyNames.Group]);
+            Assert.That((string) requirement[PropertyNames.Group], Is.Null);
 
             var expectedCategories = new[] { "167b5cb0-766e-4ab2-b728-a9c9a662b017" };
             var categoriesArray = (JArray) requirement[PropertyNames.Category];
@@ -252,20 +252,20 @@ namespace WebservicesIntegrationTests
             if (requirement != null)
             {
                 // verify the amount of returned properties 
-                Assert.AreEqual(14, requirement.Children().Count());
+                Assert.That(requirement.Children().Count(), Is.EqualTo(14));
 
                 // assert that the properties are what is expected
-                Assert.AreEqual("614e2a69-d602-46be-9311-2fb4d3273e88", (string) requirement[PropertyNames.Iid]);
-                Assert.AreEqual(1, (int) requirement[PropertyNames.RevisionNumber]);
-                Assert.AreEqual("Requirement", (string) requirement[PropertyNames.ClassKind]);
+                Assert.That((string) requirement[PropertyNames.Iid], Is.EqualTo("614e2a69-d602-46be-9311-2fb4d3273e88"));
+                Assert.That((int) requirement[PropertyNames.RevisionNumber], Is.EqualTo(1));
+                Assert.That((string) requirement[PropertyNames.ClassKind], Is.EqualTo("Requirement"));
 
-                Assert.AreEqual("Test Requirement 2", (string) requirement[PropertyNames.Name]);
-                Assert.AreEqual("TestRequirementTwo", (string) requirement[PropertyNames.ShortName]);
+                Assert.That((string) requirement[PropertyNames.Name], Is.EqualTo("Test Requirement 2"));
+                Assert.That((string) requirement[PropertyNames.ShortName], Is.EqualTo("TestRequirementTwo"));
 
-                Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) requirement[PropertyNames.Owner]);
+                Assert.That((string) requirement[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
                 Assert.IsFalse((bool) requirement[PropertyNames.IsDeprecated]);
-                Assert.AreEqual("d3474e6a-f9ac-4d1a-91d9-6f8be06a03b5", (string) requirement[PropertyNames.Group]);
+                Assert.That((string) requirement[PropertyNames.Group], Is.EqualTo("d3474e6a-f9ac-4d1a-91d9-6f8be06a03b5"));
 
                 expectedCategories = new string[] { };
                 categoriesArray = (JArray) requirement[PropertyNames.Category];
@@ -313,7 +313,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             var definition = jArray.Single(x => (string) x[PropertyNames.Iid] == "3d8fa7f7-5235-4fe4-a026-207015e5822c");
-            Assert.AreEqual(2, (int) definition[PropertyNames.RevisionNumber]);
+            Assert.That((int) definition[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             SiteDirectoryTestFixture.AddDomainExpertUserJane(this, out var userName, out var passWord);
             this.CreateNewWebClientForUser(userName, passWord);
@@ -326,7 +326,7 @@ namespace WebservicesIntegrationTests
             // Jane is not allowed to update
             var exception = Assert.Catch<WebException>(() => this.WebClient.PostDto(iterationUri, postBody));
             var errorMessage = this.WebClient.ExtractExceptionStringFromResponse(exception.Response);
-            Assert.AreEqual(HttpStatusCode.Unauthorized, ((HttpWebResponse) exception.Response).StatusCode);
+            Assert.That(((HttpWebResponse) exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
             Assert.IsTrue(errorMessage.Contains("The person Jane does not have an appropriate update permission for Definition."));
         }
     }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/RequirementsGroup/RequirementsGroupTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/RequirementsGroup/RequirementsGroupTestFixture.cs
@@ -87,11 +87,11 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
             
             var engineeeringModel = jArray.Single(x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int) engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int) engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // get a specific RequirementsSpecification from the result by it's unique id
             var requirementsSpecification = jArray.Single(x => (string)x[PropertyNames.Iid] == "8d0734f4-ca4b-4611-9187-f6970e2b02bc");
-            Assert.AreEqual(2, (int)requirementsSpecification[PropertyNames.RevisionNumber]);
+            Assert.That((int)requirementsSpecification[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedRequirementsGroups = new string[] { "cffa1f05-41b8-4b89-922b-9a9505809601" };
             var requirementsGroupsArray = (JArray)requirementsSpecification[PropertyNames.Group];
@@ -102,17 +102,17 @@ namespace WebservicesIntegrationTests
             var requirementsGroup = jArray.Single(x => (string)x[PropertyNames.Iid] == "cffa1f05-41b8-4b89-922b-9a9505809601");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(10, requirementsGroup.Children().Count());
+            Assert.That(requirementsGroup.Children().Count(), Is.EqualTo(10));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("cffa1f05-41b8-4b89-922b-9a9505809601", (string)requirementsGroup[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)requirementsGroup[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("RequirementsGroup", (string)requirementsGroup[PropertyNames.ClassKind]);
+            Assert.That((string)requirementsGroup[PropertyNames.Iid], Is.EqualTo("cffa1f05-41b8-4b89-922b-9a9505809601"));
+            Assert.That((int)requirementsGroup[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string)requirementsGroup[PropertyNames.ClassKind], Is.EqualTo("RequirementsGroup"));
 
-            Assert.AreEqual("Test Requirements Group post test", (string)requirementsGroup[PropertyNames.Name]);
-            Assert.AreEqual("TestRequirementsGroupPostTest", (string)requirementsGroup[PropertyNames.ShortName]);
+            Assert.That((string)requirementsGroup[PropertyNames.Name], Is.EqualTo("Test Requirements Group post test"));
+            Assert.That((string)requirementsGroup[PropertyNames.ShortName], Is.EqualTo("TestRequirementsGroupPostTest"));
 
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string)requirementsGroup[PropertyNames.Owner]);
+            Assert.That((string)requirementsGroup[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             var expectedAliases = new string[] { };
             var aliasesArray = (JArray)requirementsGroup[PropertyNames.Alias];
@@ -149,11 +149,11 @@ namespace WebservicesIntegrationTests
             Assert.That(jArray.Count, Is.EqualTo(3));
 
             var engineeeringModel = jArray.Single(x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int)engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int)engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // get a specific RequirementsSpecification from the result by it's unique id
             var requirementsSpecification = jArray.Single(x => (string)x[PropertyNames.Iid] == "bf0cde90-9086-43d5-bcff-32a2f8331800");
-            Assert.AreEqual(2, (int)requirementsSpecification[PropertyNames.RevisionNumber]);
+            Assert.That((int)requirementsSpecification[PropertyNames.RevisionNumber], Is.EqualTo(2));
             var expectedRequirementsGroups = new string[] { };
             var requirementsGroupsArray = (JArray)requirementsSpecification[PropertyNames.Group];
             IList<string> groups = requirementsGroupsArray.Select(x => (string)x).ToList();
@@ -161,24 +161,24 @@ namespace WebservicesIntegrationTests
 
             // get a specific Requirement from the result by it's unique id
             var requirement = jArray.Single(x => (string)x[PropertyNames.Iid] == "614e2a69-d602-46be-9311-2fb4d3273e88");
-            Assert.AreEqual(2, (int)requirement[PropertyNames.RevisionNumber]);
-            Assert.IsNull((string)requirement[PropertyNames.Group]);
+            Assert.That((int)requirement[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string)requirement[PropertyNames.Group], Is.Null);
         }
 
         public static void VerifyProperties(JToken requirementsGroup)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(10, requirementsGroup.Children().Count());
+            Assert.That(requirementsGroup.Children().Count(), Is.EqualTo(10));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("d3474e6a-f9ac-4d1a-91d9-6f8be06a03b5", (string)requirementsGroup[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int)requirementsGroup[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("RequirementsGroup", (string)requirementsGroup[PropertyNames.ClassKind]);
+            Assert.That((string)requirementsGroup[PropertyNames.Iid], Is.EqualTo("d3474e6a-f9ac-4d1a-91d9-6f8be06a03b5"));
+            Assert.That((int)requirementsGroup[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string)requirementsGroup[PropertyNames.ClassKind], Is.EqualTo("RequirementsGroup"));
 
-            Assert.AreEqual("Test Requirements Group", (string)requirementsGroup[PropertyNames.Name]);
-            Assert.AreEqual("TestRequirementsGroup", (string)requirementsGroup[PropertyNames.ShortName]);
+            Assert.That((string)requirementsGroup[PropertyNames.Name], Is.EqualTo("Test Requirements Group"));
+            Assert.That((string)requirementsGroup[PropertyNames.ShortName], Is.EqualTo("TestRequirementsGroup"));
 
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string)requirementsGroup[PropertyNames.Owner]);
+            Assert.That((string)requirementsGroup[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             var expectedAliases = new string[] { };
             var aliasesArray = (JArray)requirementsGroup[PropertyNames.Alias];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/RequirementsSpecification/RequirementsSpecificationTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/RequirementsSpecification/RequirementsSpecificationTestFixture.cs
@@ -42,7 +42,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(requirementsSpecificationUri);
 
             // verify the number of RequirementsSpecification object 
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             // get a specific RequirementsSpecification from the result by it's unique id
             var requirementsSpecification = jArray.Single(x => (string)x[PropertyNames.Iid] == "bf0cde90-9086-43d5-bcff-32a2f8331800");
@@ -84,10 +84,10 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(iterationUri, postBody);
 
             var engineeeringModel = jArray.Single(x => (string)x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
-            Assert.AreEqual(2, (int)engineeeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((int)engineeeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var iteration = jArray.Single(x => (string)x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
-            Assert.AreEqual(2, (int)iteration[PropertyNames.RevisionNumber]);
+            Assert.That((int)iteration[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedRequirementsSpecifications = new[]
                                                          {
@@ -102,17 +102,17 @@ namespace WebservicesIntegrationTests
             var requirementsSpecification = jArray.Single(x => (string)x[PropertyNames.Iid] == "272e59f8-267a-4e5f-84eb-6d1b495bf4c7");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(12, requirementsSpecification.Children().Count());
+            Assert.That(requirementsSpecification.Children().Count(), Is.EqualTo(12));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("272e59f8-267a-4e5f-84eb-6d1b495bf4c7", (string)requirementsSpecification[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)requirementsSpecification[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("RequirementsSpecification", (string)requirementsSpecification[PropertyNames.ClassKind]);
+            Assert.That((string)requirementsSpecification[PropertyNames.Iid], Is.EqualTo("272e59f8-267a-4e5f-84eb-6d1b495bf4c7"));
+            Assert.That((int)requirementsSpecification[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string)requirementsSpecification[PropertyNames.ClassKind], Is.EqualTo("RequirementsSpecification"));
 
-            Assert.AreEqual("Test Requirements Specification 3", (string)requirementsSpecification[PropertyNames.Name]);
-            Assert.AreEqual("TestRequirementsSpecification3", (string)requirementsSpecification[PropertyNames.ShortName]);
+            Assert.That((string)requirementsSpecification[PropertyNames.Name], Is.EqualTo("Test Requirements Specification 3"));
+            Assert.That((string)requirementsSpecification[PropertyNames.ShortName], Is.EqualTo("TestRequirementsSpecification3"));
 
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string)requirementsSpecification[PropertyNames.Owner]);
+            Assert.That((string)requirementsSpecification[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             Assert.IsFalse((bool)requirementsSpecification[PropertyNames.IsDeprecated]);
 
@@ -145,23 +145,17 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken requirementsSpecification)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(12, requirementsSpecification.Children().Count());
+            Assert.That(requirementsSpecification.Children().Count(), Is.EqualTo(12));
 
             // assert that the properties are what is expected
-            Assert.AreEqual(
-                "bf0cde90-9086-43d5-bcff-32a2f8331800",
-                (string)requirementsSpecification[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int)requirementsSpecification[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("RequirementsSpecification", (string)requirementsSpecification[PropertyNames.ClassKind]);
+            Assert.That((string)requirementsSpecification[PropertyNames.Iid], Is.EqualTo("bf0cde90-9086-43d5-bcff-32a2f8331800"));
+            Assert.That((int)requirementsSpecification[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string)requirementsSpecification[PropertyNames.ClassKind], Is.EqualTo("RequirementsSpecification"));
 
-            Assert.AreEqual("Test Requirements Specification", (string)requirementsSpecification[PropertyNames.Name]);
-            Assert.AreEqual(
-                "TestRequirementsSpecification",
-                (string)requirementsSpecification[PropertyNames.ShortName]);
+            Assert.That((string)requirementsSpecification[PropertyNames.Name], Is.EqualTo("Test Requirements Specification"));
+            Assert.That((string)requirementsSpecification[PropertyNames.ShortName], Is.EqualTo("TestRequirementsSpecification"));
 
-            Assert.AreEqual(
-                "0e92edde-fdff-41db-9b1d-f2e484f12535",
-                (string)requirementsSpecification[PropertyNames.Owner]);
+            Assert.That((string)requirementsSpecification[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
 
             Assert.IsFalse((bool)requirementsSpecification[PropertyNames.IsDeprecated]);
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/RuleVerification/RuleVerificationTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/RuleVerification/RuleVerificationTestFixture.cs
@@ -45,7 +45,7 @@ namespace WebservicesIntegrationTests
             var engineeringModel = jArray.Single(x => (string) x[PropertyNames.Iid] == "9ec982e4-ef72-4953-aa85-b158a95d8d56");
 
             // Verify the amount of returned properties of the EngineeringModel
-            Assert.AreEqual(8, engineeringModel.Children().Count());
+            Assert.That(engineeringModel.Children().Count(), Is.EqualTo(8));
 
             // Assert the properties of EngineeringModel have expected values
             var expectedIterations = new[] { "e163c5ad-f32b-4387-b805-f4b34600bc2c" };
@@ -63,25 +63,25 @@ namespace WebservicesIntegrationTests
             IList<string> commonFileStores = commonFileStoresArray.Select(x => (string) x).ToList();
             Assert.That(commonFileStores, Is.EquivalentTo(expectedCommonFileStores));
 
-            Assert.AreEqual("EngineeringModel", (string) engineeringModel[PropertyNames.ClassKind]);
-            Assert.AreEqual("116f6253-89bb-47d4-aa24-d11d197e43c9", (string) engineeringModel[PropertyNames.EngineeringModelSetup]);
-            Assert.AreEqual("9ec982e4-ef72-4953-aa85-b158a95d8d56", (string) engineeringModel[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) engineeringModel[PropertyNames.RevisionNumber]);
+            Assert.That((string) engineeringModel[PropertyNames.ClassKind], Is.EqualTo("EngineeringModel"));
+            Assert.That((string) engineeringModel[PropertyNames.EngineeringModelSetup], Is.EqualTo("116f6253-89bb-47d4-aa24-d11d197e43c9"));
+            Assert.That((string) engineeringModel[PropertyNames.Iid], Is.EqualTo("9ec982e4-ef72-4953-aa85-b158a95d8d56"));
+            Assert.That((int) engineeringModel[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // get a specific RuleVerification from the result by it's unique id
             var ruleVerificationList = jArray.Single(x => (string) x[PropertyNames.Iid] == "dc482120-2a11-439b-913d-6a924de9ee5f");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(10, ruleVerificationList.Children().Count());
+            Assert.That(ruleVerificationList.Children().Count(), Is.EqualTo(10));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("dc482120-2a11-439b-913d-6a924de9ee5f", (string) ruleVerificationList[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) ruleVerificationList[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("RuleVerificationList", (string) ruleVerificationList[PropertyNames.ClassKind]);
+            Assert.That((string) ruleVerificationList[PropertyNames.Iid], Is.EqualTo("dc482120-2a11-439b-913d-6a924de9ee5f"));
+            Assert.That((int) ruleVerificationList[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) ruleVerificationList[PropertyNames.ClassKind], Is.EqualTo("RuleVerificationList"));
 
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) ruleVerificationList[PropertyNames.Owner]);
-            Assert.AreEqual("Test RuleVerificationList", (string) ruleVerificationList[PropertyNames.Name]);
-            Assert.AreEqual("TestRuleVerificationList", (string) ruleVerificationList[PropertyNames.ShortName]);
+            Assert.That((string) ruleVerificationList[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
+            Assert.That((string) ruleVerificationList[PropertyNames.Name], Is.EqualTo("Test RuleVerificationList"));
+            Assert.That((string) ruleVerificationList[PropertyNames.ShortName], Is.EqualTo("TestRuleVerificationList"));
 
             var expectedAliases = new string[] { };
             var aliasesArray = (JArray) ruleVerificationList[PropertyNames.Alias];
@@ -115,31 +115,31 @@ namespace WebservicesIntegrationTests
             var builtInRuleVerification = jArray.Single(x => (string) x[PropertyNames.Iid] == "4efbc475-37f3-4219-8571-e896a78545d5");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(7, builtInRuleVerification.Children().Count());
+            Assert.That(builtInRuleVerification.Children().Count(), Is.EqualTo(7));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("4efbc475-37f3-4219-8571-e896a78545d5", (string) builtInRuleVerification[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) builtInRuleVerification[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("BuiltInRuleVerification", (string) builtInRuleVerification[PropertyNames.ClassKind]);
-            Assert.AreEqual("Test Built In Rule Verification", (string) builtInRuleVerification[PropertyNames.Name]);
-            Assert.AreEqual("NONE", (string) builtInRuleVerification[PropertyNames.Status]);
-            Assert.IsNull((string) builtInRuleVerification[PropertyNames.ExecutedOn]);
+            Assert.That((string) builtInRuleVerification[PropertyNames.Iid], Is.EqualTo("4efbc475-37f3-4219-8571-e896a78545d5"));
+            Assert.That((int) builtInRuleVerification[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) builtInRuleVerification[PropertyNames.ClassKind], Is.EqualTo("BuiltInRuleVerification"));
+            Assert.That((string) builtInRuleVerification[PropertyNames.Name], Is.EqualTo("Test Built In Rule Verification"));
+            Assert.That((string) builtInRuleVerification[PropertyNames.Status], Is.EqualTo("NONE"));
+            Assert.That((string) builtInRuleVerification[PropertyNames.ExecutedOn], Is.Null);
             Assert.IsFalse((bool) builtInRuleVerification[PropertyNames.IsActive]);
 
             // get a specific RuleVerification from the result by it's unique id
             var userRuleVerification = jArray.Single(x => (string) x[PropertyNames.Iid] == "486f4b97-fcb1-409e-b5c0-057c240f41b6");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(7, userRuleVerification.Children().Count());
+            Assert.That(userRuleVerification.Children().Count(), Is.EqualTo(7));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("486f4b97-fcb1-409e-b5c0-057c240f41b6", (string) userRuleVerification[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) userRuleVerification[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("UserRuleVerification", (string) userRuleVerification[PropertyNames.ClassKind]);
-            Assert.AreEqual("NONE", (string) userRuleVerification[PropertyNames.Status]);
-            Assert.IsNull((string) userRuleVerification[PropertyNames.ExecutedOn]);
+            Assert.That((string) userRuleVerification[PropertyNames.Iid], Is.EqualTo("486f4b97-fcb1-409e-b5c0-057c240f41b6"));
+            Assert.That((int) userRuleVerification[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) userRuleVerification[PropertyNames.ClassKind], Is.EqualTo("UserRuleVerification"));
+            Assert.That((string) userRuleVerification[PropertyNames.Status], Is.EqualTo("NONE"));
+            Assert.That((string) userRuleVerification[PropertyNames.ExecutedOn], Is.Null);
             Assert.IsFalse((bool) userRuleVerification[PropertyNames.IsActive]);
-            Assert.AreEqual("8a5cd66e-7313-4843-813f-37081ca81bb8", (string) userRuleVerification[PropertyNames.Rule]);
+            Assert.That((string) userRuleVerification[PropertyNames.Rule], Is.EqualTo("8a5cd66e-7313-4843-813f-37081ca81bb8"));
         }
 
         [Test]
@@ -161,7 +161,7 @@ namespace WebservicesIntegrationTests
             Assert.That(jArray.Count, Is.EqualTo(3));
 
             var ruleVerificationList = jArray.Single(x => (string) x[PropertyNames.Iid] == "dc482120-2a11-439b-913d-6a924de9ee5f");
-            Assert.AreEqual(3, (int) ruleVerificationList[PropertyNames.RevisionNumber]);
+            Assert.That((int) ruleVerificationList[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             var expectedRuleVerifications = new List<OrderedItem>
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/RuleVerificationList/RuleVerificationListTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/RuleVerificationList/RuleVerificationListTestFixture.cs
@@ -82,16 +82,16 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken ruleVerificationList)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(10, ruleVerificationList.Children().Count());
+            Assert.That(ruleVerificationList.Children().Count(), Is.EqualTo(10));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("dc482120-2a11-439b-913d-6a924de9ee5f", (string) ruleVerificationList[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) ruleVerificationList[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("RuleVerificationList", (string) ruleVerificationList[PropertyNames.ClassKind]);
+            Assert.That((string) ruleVerificationList[PropertyNames.Iid], Is.EqualTo("dc482120-2a11-439b-913d-6a924de9ee5f"));
+            Assert.That((int) ruleVerificationList[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) ruleVerificationList[PropertyNames.ClassKind], Is.EqualTo("RuleVerificationList"));
 
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) ruleVerificationList[PropertyNames.Owner]);
-            Assert.AreEqual("Test RuleVerificationList", (string) ruleVerificationList[PropertyNames.Name]);
-            Assert.AreEqual("TestRuleVerificationList", (string) ruleVerificationList[PropertyNames.ShortName]);
+            Assert.That((string) ruleVerificationList[PropertyNames.Owner], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
+            Assert.That((string) ruleVerificationList[PropertyNames.Name], Is.EqualTo("Test RuleVerificationList"));
+            Assert.That((string) ruleVerificationList[PropertyNames.ShortName], Is.EqualTo("TestRuleVerificationList"));
 
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) ruleVerificationList[PropertyNames.Alias];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Section/SectionTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/Section/SectionTestFixture.cs
@@ -60,7 +60,7 @@ namespace WebservicesIntegrationTests
 
             var book = jArray.Single(x => (string) x[PropertyNames.Iid] == "f84b5d72-be4d-418c-90db-19e311e75be3");
 
-            Assert.AreEqual(12, book.Children().Count());
+            Assert.That(book.Children().Count(), Is.EqualTo(12));
 
             var sectionList = JsonConvert.DeserializeObject<List<OrderedItem>>(
                 book[PropertyNames.Section].ToString());
@@ -77,8 +77,8 @@ namespace WebservicesIntegrationTests
             var section1 = jArray.Single(x => (string) x[PropertyNames.Iid] == "c2eccf19-a040-4756-8298-8678d7149c8f");
             var section2 = jArray.Single(x => (string) x[PropertyNames.Iid] == "b47ccf37-caa8-4015-b0da-8620894aabce");
 
-            Assert.AreEqual(12, section1.Children().Count());
-            Assert.AreEqual(12, section2.Children().Count());
+            Assert.That(section1.Children().Count(), Is.EqualTo(12));
+            Assert.That(section2.Children().Count(), Is.EqualTo(12));
 
             postBodyPath = this.GetPath("Tests/EngineeringModel/Section/PostDeleteSection.json");
             postBody = this.GetJsonFromFile(postBodyPath);
@@ -86,7 +86,7 @@ namespace WebservicesIntegrationTests
 
             book = jArray.Single(x => (string) x[PropertyNames.Iid] == "f84b5d72-be4d-418c-90db-19e311e75be3");
 
-            Assert.AreEqual(12, book.Children().Count());
+            Assert.That(book.Children().Count(), Is.EqualTo(12));
 
             sectionList = JsonConvert.DeserializeObject<List<OrderedItem>>(book[PropertyNames.Section].ToString());
 

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/SimpleParameterValue/SimpleParameterValueTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/SimpleParameterValue/SimpleParameterValueTestFixture.cs
@@ -41,7 +41,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(simpleParameterValueUri);
 
             //check if there are the correct amount of SimpleParameterValue objects 
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             SimpleParameterValueTestFixture.VerifyProperties(jArray);
         }
@@ -57,7 +57,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(simpleParameterValueUri);
 
             // verify that the correct amount of objects is returned
-            Assert.AreEqual(6, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(6));
 
             // get a specific Iteration from the result by it's unique id
             var iteration = jArray.Single(x => (string) x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
@@ -86,24 +86,24 @@ namespace WebservicesIntegrationTests
             var simpleParameterValueObject = simpleParameterValue.Single(x => (string) x[PropertyNames.Iid] == "ef3b5740-6e0e-463c-99df-f255e38a32b6");
 
             // assert that the properties are what is expected
-            Assert.AreEqual("ef3b5740-6e0e-463c-99df-f255e38a32b6", (string) simpleParameterValueObject[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) simpleParameterValueObject[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SimpleParameterValue", (string) simpleParameterValueObject[PropertyNames.ClassKind]);
+            Assert.That((string) simpleParameterValueObject[PropertyNames.Iid], Is.EqualTo("ef3b5740-6e0e-463c-99df-f255e38a32b6"));
+            Assert.That((int) simpleParameterValueObject[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) simpleParameterValueObject[PropertyNames.ClassKind], Is.EqualTo("SimpleParameterValue"));
 
-            Assert.IsNull((string) simpleParameterValueObject[PropertyNames.Scale]);
-            Assert.AreEqual("35a9cf05-4eba-4cda-b60c-7cfeaac8f892", (string) simpleParameterValueObject[PropertyNames.ParameterType]);
-            Assert.AreEqual("[\"true\"]", (string) simpleParameterValueObject[PropertyNames.Value]);
+            Assert.That((string) simpleParameterValueObject[PropertyNames.Scale], Is.Null);
+            Assert.That((string) simpleParameterValueObject[PropertyNames.ParameterType], Is.EqualTo("35a9cf05-4eba-4cda-b60c-7cfeaac8f892"));
+            Assert.That((string) simpleParameterValueObject[PropertyNames.Value], Is.EqualTo("[\"true\"]"));
 
             simpleParameterValueObject = simpleParameterValue.Single(x => (string) x[PropertyNames.Iid] == "bcedefb0-b3ee-4a0b-8137-6561fa23b37f");
 
             // assert that the properties are what is expected
-            Assert.AreEqual("bcedefb0-b3ee-4a0b-8137-6561fa23b37f", (string) simpleParameterValueObject[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) simpleParameterValueObject[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SimpleParameterValue", (string) simpleParameterValueObject[PropertyNames.ClassKind]);
+            Assert.That((string) simpleParameterValueObject[PropertyNames.Iid], Is.EqualTo("bcedefb0-b3ee-4a0b-8137-6561fa23b37f"));
+            Assert.That((int) simpleParameterValueObject[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) simpleParameterValueObject[PropertyNames.ClassKind], Is.EqualTo("SimpleParameterValue"));
 
-            Assert.IsNull((string) simpleParameterValueObject[PropertyNames.Scale]);
-            Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254", (string) simpleParameterValueObject[PropertyNames.ParameterType]);
-            Assert.AreEqual("[\"test\"]", (string) simpleParameterValueObject[PropertyNames.Value]);
+            Assert.That((string) simpleParameterValueObject[PropertyNames.Scale], Is.Null);
+            Assert.That((string) simpleParameterValueObject[PropertyNames.ParameterType], Is.EqualTo("a21c15c4-3e1e-46b5-b109-5063dec1e254"));
+            Assert.That((string) simpleParameterValueObject[PropertyNames.Value], Is.EqualTo("[\"test\"]"));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/UserRuleVerification/UserRuleVerificationTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/EngineeringModel/UserRuleVerification/UserRuleVerificationTestFixture.cs
@@ -41,7 +41,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(userRuleVerificationUri);
 
             //check if there are 2 RuleVerification objects 
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             // get a specific UserRuleVerification from the result by it's unique id
             var userRuleVerification = jArray.Single(x => (string) x[PropertyNames.Iid] == "c953263c-fc25-4048-9bb6-343a10200a0c");
@@ -59,7 +59,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(userRuleVerificationUri);
 
             //check if there are 5 objects
-            Assert.AreEqual(5, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(5));
 
             // get a specific Iteration from the result by it's unique id
             var iteration = jArray.Single(x => (string) x[PropertyNames.Iid] == "e163c5ad-f32b-4387-b805-f4b34600bc2c");
@@ -83,15 +83,15 @@ namespace WebservicesIntegrationTests
         /// </param>
         public static void VerifyProperties(JToken userRuleVerification)
         {
-            Assert.AreEqual(7, userRuleVerification.Children().Count());
+            Assert.That(userRuleVerification.Children().Count(), Is.EqualTo(7));
 
-            Assert.AreEqual("c953263c-fc25-4048-9bb6-343a10200a0c", (string) userRuleVerification[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) userRuleVerification[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("UserRuleVerification", (string) userRuleVerification[PropertyNames.ClassKind]);
-            Assert.AreEqual("PASSED", (string) userRuleVerification[PropertyNames.Status]);
-            Assert.IsNull((string) userRuleVerification[PropertyNames.ExecutedOn]);
+            Assert.That((string) userRuleVerification[PropertyNames.Iid], Is.EqualTo("c953263c-fc25-4048-9bb6-343a10200a0c"));
+            Assert.That((int) userRuleVerification[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) userRuleVerification[PropertyNames.ClassKind], Is.EqualTo("UserRuleVerification"));
+            Assert.That((string) userRuleVerification[PropertyNames.Status], Is.EqualTo("PASSED"));
+            Assert.That((string) userRuleVerification[PropertyNames.ExecutedOn], Is.Null);
             Assert.IsTrue((bool) userRuleVerification[PropertyNames.IsActive]);
-            Assert.AreEqual("8a5cd66e-7313-4843-813f-37081ca81bb8", (string) userRuleVerification[PropertyNames.Rule]);
+            Assert.That((string) userRuleVerification[PropertyNames.Rule], Is.EqualTo("8a5cd66e-7313-4843-813f-37081ca81bb8"));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ArrayParameterType/ArrayParameterTypeTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ArrayParameterType/ArrayParameterTypeTestFixture.cs
@@ -83,7 +83,7 @@ namespace WebservicesIntegrationTests
             var component_2 = jArray.Single(x => (string) x[PropertyNames.Iid] == "0715f517-1f8b-462d-9189-b4ff20548266");
             Assert.That((int)component_2[PropertyNames.RevisionNumber], Is.EqualTo(2));
             Assert.That((string)component_2[PropertyNames.ParameterType], Is.EqualTo("35a9cf05-4eba-4cda-b60c-7cfeaac8f892"));
-            Assert.IsNull((string) component_2[PropertyNames.Scale]);
+            Assert.That((string) component_2[PropertyNames.Scale], Is.Null);
             Assert.That((string)component_2[PropertyNames.ShortName], Is.EqualTo("{2;1}"));
 
             //Reorder Dimension

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Constant/ConstantTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Constant/ConstantTestFixture.cs
@@ -330,7 +330,7 @@ namespace WebservicesIntegrationTests
 
             Assert.That((string)constant[PropertyNames.Value], Is.EqualTo("[\"word\"]"));
 
-            Assert.IsNull((string)constant[PropertyNames.Scale]);
+            Assert.That((string)constant[PropertyNames.Scale], Is.Null);
 
             var expectedCategories = new string[] { };
             var categoriesArray = (JArray)constant[PropertyNames.Category];
@@ -378,7 +378,7 @@ namespace WebservicesIntegrationTests
 
             Assert.That((string)constant[PropertyNames.Value], Is.EqualTo("[\"true\"]"));
 
-            Assert.IsNull((string) constant[PropertyNames.Scale]);
+            Assert.That((string) constant[PropertyNames.Scale], Is.Null);
 
             var expectedCategories = new string[] {};
             var categoriesArray = (JArray) constant[PropertyNames.Category];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/CyclicRatioScale/CyclicRatioScaleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/CyclicRatioScale/CyclicRatioScaleTestFixture.cs
@@ -397,7 +397,7 @@ namespace WebservicesIntegrationTests
             Assert.IsTrue((bool) cyclicRatioScale["isMinimumInclusive"]);
             Assert.That((string)cyclicRatioScale["maximumPermissibleValue"], Is.EqualTo("360"));
             Assert.IsTrue((bool) cyclicRatioScale["isMaximumInclusive"]);
-            Assert.IsNull((string) cyclicRatioScale["positiveValueConnotation"]);
+            Assert.That((string) cyclicRatioScale["positiveValueConnotation"], Is.Null);
             Assert.That((string)cyclicRatioScale["negativeValueConnotation"], Is.EqualTo(""));
             
             var expectedMappingToReferenceScales = new string[] {};

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/DerivedQuantityKind/DerivedQuantityKindTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/DerivedQuantityKind/DerivedQuantityKindTestFixture.cs
@@ -114,7 +114,7 @@ namespace WebservicesIntegrationTests
 
             Assert.That((string)derivedQuantityKind[PropertyNames.Symbol], Is.EqualTo("symbol"));
             Assert.That((string)derivedQuantityKind[PropertyNames.DefaultScale], Is.EqualTo("53e82aeb-c42c-475c-b6bf-a102af883471"));
-            Assert.IsNull((string) derivedQuantityKind[PropertyNames.QuantityDimensionSymbol]);
+            Assert.That((string) derivedQuantityKind[PropertyNames.QuantityDimensionSymbol], Is.Null);
 
             var expectedPossibleScales = new string[]
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/IntervalScale/IntervalScaleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/IntervalScale/IntervalScaleTestFixture.cs
@@ -86,31 +86,31 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken intervalScale)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(19, intervalScale.Children().Count());
+            Assert.That(intervalScale.Children().Count(), Is.EqualTo(19));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("6326d1ea-c032-4a4b-8b10-608c59f1a923", (string) intervalScale["iid"]);
-            Assert.AreEqual(1, (int) intervalScale["revisionNumber"]);
-            Assert.AreEqual("IntervalScale", (string) intervalScale["classKind"]);
+            Assert.That((string) intervalScale["iid"], Is.EqualTo("6326d1ea-c032-4a4b-8b10-608c59f1a923"));
+            Assert.That((int) intervalScale["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) intervalScale["classKind"], Is.EqualTo("IntervalScale"));
 
-            Assert.AreEqual("Test Interval Scale", (string) intervalScale["name"]);
-            Assert.AreEqual("TestIntervalScale", (string) intervalScale["shortName"]);
+            Assert.That((string) intervalScale["name"], Is.EqualTo("Test Interval Scale"));
+            Assert.That((string) intervalScale["shortName"], Is.EqualTo("TestIntervalScale"));
 
             Assert.IsFalse((bool) intervalScale["isDeprecated"]);
-            Assert.AreEqual("56842970-3915-4369-8712-61cfd8273ef9", (string) intervalScale["unit"]);
+            Assert.That((string) intervalScale["unit"], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
 
             var expectedValueDefinitions = new string[] {};
             var valueDefinitionsArray = (JArray) intervalScale["valueDefinition"];
             IList<string> valueDefinitions = valueDefinitionsArray.Select(x => (string) x).ToList();
             Assert.That(valueDefinitions, Is.EquivalentTo(expectedValueDefinitions));
 
-            Assert.AreEqual("NATURAL_NUMBER_SET", (string) intervalScale["numberSet"]);
-            Assert.AreEqual("1", (string) intervalScale["minimumPermissibleValue"]);
+            Assert.That((string) intervalScale["numberSet"], Is.EqualTo("NATURAL_NUMBER_SET"));
+            Assert.That((string) intervalScale["minimumPermissibleValue"], Is.EqualTo("1"));
             Assert.IsTrue((bool) intervalScale["isMinimumInclusive"]);
-            Assert.AreEqual("2", (string) intervalScale["maximumPermissibleValue"]);
+            Assert.That((string) intervalScale["maximumPermissibleValue"], Is.EqualTo("2"));
             Assert.IsTrue((bool) intervalScale["isMaximumInclusive"]);
-            Assert.AreEqual("positive Value Connotation", (string) intervalScale["positiveValueConnotation"]);
-            Assert.AreEqual("negative Value Connotation", (string) intervalScale["negativeValueConnotation"]);
+            Assert.That((string) intervalScale["positiveValueConnotation"], Is.EqualTo("positive Value Connotation"));
+            Assert.That((string) intervalScale["negativeValueConnotation"], Is.EqualTo("negative Value Connotation"));
 
             var expectedMappingToReferenceScales = new string[] {};
             var mappingToReferenceScalesArray = (JArray) intervalScale["mappingToReferenceScale"];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/LinearConversionUnit/LinearConversionUnitTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/LinearConversionUnit/LinearConversionUnitTestFixture.cs
@@ -86,19 +86,19 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken linearConversionUnit)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(11, linearConversionUnit.Children().Count());
+            Assert.That(linearConversionUnit.Children().Count(), Is.EqualTo(11));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("12f48e1a-2996-46cc-8dc1-faf4e69ae115", (string) linearConversionUnit["iid"]);
-            Assert.AreEqual(1, (int) linearConversionUnit["revisionNumber"]);
-            Assert.AreEqual("LinearConversionUnit", (string) linearConversionUnit["classKind"]);
+            Assert.That((string) linearConversionUnit["iid"], Is.EqualTo("12f48e1a-2996-46cc-8dc1-faf4e69ae115"));
+            Assert.That((int) linearConversionUnit["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) linearConversionUnit["classKind"], Is.EqualTo("LinearConversionUnit"));
 
             Assert.IsFalse((bool) linearConversionUnit["isDeprecated"]);
-            Assert.AreEqual("Test Linear Conversion Unit", (string) linearConversionUnit["name"]);
-            Assert.AreEqual("testLinearConversionUnit", (string) linearConversionUnit["shortName"]);
+            Assert.That((string) linearConversionUnit["name"], Is.EqualTo("Test Linear Conversion Unit"));
+            Assert.That((string) linearConversionUnit["shortName"], Is.EqualTo("testLinearConversionUnit"));
 
-            Assert.AreEqual("56842970-3915-4369-8712-61cfd8273ef9", (string) linearConversionUnit["referenceUnit"]);
-            Assert.AreEqual("1000", (string) linearConversionUnit["conversionFactor"]);
+            Assert.That((string) linearConversionUnit["referenceUnit"], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
+            Assert.That((string) linearConversionUnit["conversionFactor"], Is.EqualTo("1000"));
 
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) linearConversionUnit["alias"];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/LogarithmicScale/LogarithmicScaleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/LogarithmicScale/LogarithmicScaleTestFixture.cs
@@ -86,24 +86,24 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken logarithmicScale)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(24, logarithmicScale.Children().Count());
+            Assert.That(logarithmicScale.Children().Count(), Is.EqualTo(24));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("007b0e60-e67c-4060-88d2-2531ef9e7d9e", (string) logarithmicScale["iid"]);
-            Assert.AreEqual(1, (int) logarithmicScale["revisionNumber"]);
-            Assert.AreEqual("LogarithmicScale", (string) logarithmicScale["classKind"]);
+            Assert.That((string) logarithmicScale["iid"], Is.EqualTo("007b0e60-e67c-4060-88d2-2531ef9e7d9e"));
+            Assert.That((int) logarithmicScale["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) logarithmicScale["classKind"], Is.EqualTo("LogarithmicScale"));
 
-            Assert.AreEqual("Test Logarithmic Scale", (string) logarithmicScale["name"]);
-            Assert.AreEqual("TestLogarithmicScale", (string) logarithmicScale["shortName"]);
-            Assert.AreEqual("TestLogarithmicScale", (string) logarithmicScale["shortName"]);
+            Assert.That((string) logarithmicScale["name"], Is.EqualTo("Test Logarithmic Scale"));
+            Assert.That((string) logarithmicScale["shortName"], Is.EqualTo("TestLogarithmicScale"));
+            Assert.That((string) logarithmicScale["shortName"], Is.EqualTo("TestLogarithmicScale"));
 
             Assert.IsFalse((bool) logarithmicScale["isDeprecated"]);
-            Assert.AreEqual("56842970-3915-4369-8712-61cfd8273ef9", (string) logarithmicScale["unit"]);
+            Assert.That((string) logarithmicScale["unit"], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
 
-            Assert.AreEqual("BASE10", (string) logarithmicScale["logarithmBase"]);
-            Assert.AreEqual("10", (string) logarithmicScale["factor"]);
-            Assert.AreEqual("1", (string) logarithmicScale["exponent"]);
-            Assert.AreEqual("4f9f3d9b-f3de-4ef5-b6cb-2e22199fab0d", (string) logarithmicScale["referenceQuantityKind"]);
+            Assert.That((string) logarithmicScale["logarithmBase"], Is.EqualTo("BASE10"));
+            Assert.That((string) logarithmicScale["factor"], Is.EqualTo("10"));
+            Assert.That((string) logarithmicScale["exponent"], Is.EqualTo("1"));
+            Assert.That((string) logarithmicScale["referenceQuantityKind"], Is.EqualTo("4f9f3d9b-f3de-4ef5-b6cb-2e22199fab0d"));
 
             var expectedReferenceQuantityValues = new string[]
             {
@@ -118,13 +118,13 @@ namespace WebservicesIntegrationTests
             IList<string> valueDefinitions = valueDefinitionsArray.Select(x => (string) x).ToList();
             Assert.That(valueDefinitions, Is.EquivalentTo(expectedValueDefinitions));
 
-            Assert.AreEqual("REAL_NUMBER_SET", (string) logarithmicScale["numberSet"]);
-            Assert.AreEqual("0", (string) logarithmicScale["minimumPermissibleValue"]);
+            Assert.That((string) logarithmicScale["numberSet"], Is.EqualTo("REAL_NUMBER_SET"));
+            Assert.That((string) logarithmicScale["minimumPermissibleValue"], Is.EqualTo("0"));
             Assert.IsFalse((bool) logarithmicScale["isMinimumInclusive"]);
-            Assert.IsNull((string) logarithmicScale["maximumPermissibleValue"]);
+            Assert.That((string) logarithmicScale["maximumPermissibleValue"], Is.Null);
             Assert.IsTrue((bool) logarithmicScale["isMaximumInclusive"]);
-            Assert.AreEqual("", logarithmicScale["positiveValueConnotation"]);
-            Assert.AreEqual("", logarithmicScale["negativeValueConnotation"]);
+            Assert.That(logarithmicScale["positiveValueConnotation"], Is.EqualTo(""));
+            Assert.That(logarithmicScale["negativeValueConnotation"], Is.EqualTo(""));
             
             var expectedMappingToReferenceScales = new string[] {};
             var mappingToReferenceScalesArray = (JArray) logarithmicScale["mappingToReferenceScale"];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ModelReferenceDataLibrary/ModelReferenceDataLibraryTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ModelReferenceDataLibrary/ModelReferenceDataLibraryTestFixture.cs
@@ -92,11 +92,11 @@ namespace WebservicesIntegrationTests
 
             //SiteDirectory properties
             var siteDirectory = jArray.Single(x => (string) x[PropertyNames.Iid] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
-            Assert.AreEqual(2, (int) siteDirectory[PropertyNames.RevisionNumber]);
+            Assert.That((int) siteDirectory[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             //SiteReferenceDataLibrary properties
             var siteRdl = jArray.Single(x => (string) x[PropertyNames.Iid] == "c454c687-ba3e-44c4-86bc-44544b2c7880");
-            Assert.AreEqual(2, (int) siteRdl[PropertyNames.RevisionNumber]);
+            Assert.That((int) siteRdl[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedRules = new string[]
             {
@@ -113,7 +113,7 @@ namespace WebservicesIntegrationTests
 
             //ModelReferenceDataLibrary properties
             var modelRdl = jArray.Single(x => (string) x[PropertyNames.Iid] == "3483f2b5-ea29-45cc-8a46-f5f598558fc3");
-            Assert.AreEqual(2, (int) modelRdl[PropertyNames.RevisionNumber]);
+            Assert.That((int) modelRdl[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             expectedRules = new string[]
             {
@@ -138,15 +138,15 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(siteDirectoryUri, postBody);
 
             //Check the amount of objects 
-            Assert.AreEqual(6, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(6));
 
             //SiteDirectory properties
             var siteDirectory = jArray.Single(x => (string) x[PropertyNames.Iid] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
-            Assert.AreEqual(2, (int) siteDirectory[PropertyNames.RevisionNumber]);
+            Assert.That((int) siteDirectory[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             //SiteReferenceDataLibrary properties
             var siteRdl = jArray.Single(x => (string) x[PropertyNames.Iid] == "c454c687-ba3e-44c4-86bc-44544b2c7880");
-            Assert.AreEqual(2, (int) siteRdl[PropertyNames.RevisionNumber]);
+            Assert.That((int) siteRdl[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedRules = new string[]
             {
@@ -175,7 +175,7 @@ namespace WebservicesIntegrationTests
 
             //ModelReferenceDataLibrary properties
             var modelRdl = jArray.Single(x => (string) x[PropertyNames.Iid] == "3483f2b5-ea29-45cc-8a46-f5f598558fc3");
-            Assert.AreEqual(2, (int) modelRdl[PropertyNames.RevisionNumber]);
+            Assert.That((int) modelRdl[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             expectedRules = new string[]
             {
@@ -201,19 +201,17 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken modelReferenceDataLibrary)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(21, modelReferenceDataLibrary.Children().Count());
+            Assert.That(modelReferenceDataLibrary.Children().Count(), Is.EqualTo(21));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("3483f2b5-ea29-45cc-8a46-f5f598558fc3",
-                (string) modelReferenceDataLibrary[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) modelReferenceDataLibrary[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ModelReferenceDataLibrary", (string) modelReferenceDataLibrary[PropertyNames.ClassKind]);
+            Assert.That((string) modelReferenceDataLibrary[PropertyNames.Iid], Is.EqualTo("3483f2b5-ea29-45cc-8a46-f5f598558fc3"));
+            Assert.That((int) modelReferenceDataLibrary[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) modelReferenceDataLibrary[PropertyNames.ClassKind], Is.EqualTo("ModelReferenceDataLibrary"));
 
-            Assert.AreEqual("Test Model Reference Data Library", (string) modelReferenceDataLibrary[PropertyNames.Name]);
-            Assert.AreEqual("TestModelReferenceDataLibrary", (string) modelReferenceDataLibrary[PropertyNames.ShortName]);
+            Assert.That((string) modelReferenceDataLibrary[PropertyNames.Name], Is.EqualTo("Test Model Reference Data Library"));
+            Assert.That((string) modelReferenceDataLibrary[PropertyNames.ShortName], Is.EqualTo("TestModelReferenceDataLibrary"));
 
-            Assert.AreEqual("c454c687-ba3e-44c4-86bc-44544b2c7880",
-                (string) modelReferenceDataLibrary[PropertyNames.RequiredRdl]);
+            Assert.That((string) modelReferenceDataLibrary[PropertyNames.RequiredRdl], Is.EqualTo("c454c687-ba3e-44c4-86bc-44544b2c7880"));
 
             var expectedDefinedCategories = new string[]
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/MultirelationshipRule/MultirelationshipRuleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/MultirelationshipRule/MultirelationshipRuleTestFixture.cs
@@ -86,21 +86,20 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken multirelationshipRule)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(13, multirelationshipRule.Children().Count());
+            Assert.That(multirelationshipRule.Children().Count(), Is.EqualTo(13));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("2615f9ec-30a4-4c0e-a9d3-1d067959c248", (string) multirelationshipRule["iid"]);
-            Assert.AreEqual(1, (int) multirelationshipRule["revisionNumber"]);
-            Assert.AreEqual("MultiRelationshipRule", (string) multirelationshipRule["classKind"]);
+            Assert.That((string) multirelationshipRule["iid"], Is.EqualTo("2615f9ec-30a4-4c0e-a9d3-1d067959c248"));
+            Assert.That((int) multirelationshipRule["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) multirelationshipRule["classKind"], Is.EqualTo("MultiRelationshipRule"));
 
             Assert.IsFalse((bool) multirelationshipRule["isDeprecated"]);
-            Assert.AreEqual("Test Multi Relationship Rule", (string) multirelationshipRule["name"]);
-            Assert.AreEqual("TestMultiRelationshipRule", (string) multirelationshipRule["shortName"]);
+            Assert.That((string) multirelationshipRule["name"], Is.EqualTo("Test Multi Relationship Rule"));
+            Assert.That((string) multirelationshipRule["shortName"], Is.EqualTo("TestMultiRelationshipRule"));
 
-            Assert.AreEqual("107fc408-7e6d-4f1a-895a-1b6a6025ac20",
-                (string) multirelationshipRule["relationshipCategory"]);
-            Assert.AreEqual(0, (int) multirelationshipRule["minRelated"]);
-            Assert.AreEqual(-1, (int) multirelationshipRule["maxRelated"]);
+            Assert.That((string) multirelationshipRule["relationshipCategory"], Is.EqualTo("107fc408-7e6d-4f1a-895a-1b6a6025ac20"));
+            Assert.That((int) multirelationshipRule["minRelated"], Is.EqualTo(0));
+            Assert.That((int) multirelationshipRule["maxRelated"], Is.EqualTo(-1));
 
             var expectedRelatedCategories = new string[]
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/NaturalLanguage/NaturalLanguageTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/NaturalLanguage/NaturalLanguageTestFixture.cs
@@ -59,7 +59,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(naturalLanguageUri);
 
             // assert that the returned object count = 2
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             var siteDirectory = jArray.Single(x => (string)x["iid"] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
             SiteDirectoryTestFixture.VerifyProperties(siteDirectory);
@@ -79,14 +79,14 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken naturalLanguage)
         {
             // verify that the amount of returned properties 
-            Assert.AreEqual(6, naturalLanguage.Children().Count());
+            Assert.That(naturalLanguage.Children().Count(), Is.EqualTo(6));
 
-            Assert.AreEqual("73bf30cc-3573-488f-8746-6c03ba47973e", (string)naturalLanguage["iid"]);
-            Assert.AreEqual(1, (int)naturalLanguage["revisionNumber"]);
-            Assert.AreEqual("NaturalLanguage", (string)naturalLanguage["classKind"]);
-            Assert.AreEqual("Test Natural Language", (string)naturalLanguage["name"]);
-            Assert.AreEqual("TNL", (string)naturalLanguage["languageCode"]);
-            Assert.AreEqual("test naive name", (string)naturalLanguage["nativeName"]);
+            Assert.That((string)naturalLanguage["iid"], Is.EqualTo("73bf30cc-3573-488f-8746-6c03ba47973e"));
+            Assert.That((int)naturalLanguage["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string)naturalLanguage["classKind"], Is.EqualTo("NaturalLanguage"));
+            Assert.That((string)naturalLanguage["name"], Is.EqualTo("Test Natural Language"));
+            Assert.That((string)naturalLanguage["languageCode"], Is.EqualTo("TNL"));
+            Assert.That((string)naturalLanguage["nativeName"], Is.EqualTo("test naive name"));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/OrdinalScale/OrdinalScaleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/OrdinalScale/OrdinalScaleTestFixture.cs
@@ -86,19 +86,19 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken ordinalScale)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(20, ordinalScale.Children().Count());
+            Assert.That(ordinalScale.Children().Count(), Is.EqualTo(20));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("541037e2-9f6a-466c-b56f-a09f81f36576", (string) ordinalScale["iid"]);
-            Assert.AreEqual(1, (int) ordinalScale["revisionNumber"]);
-            Assert.AreEqual("OrdinalScale", (string) ordinalScale["classKind"]);
+            Assert.That((string) ordinalScale["iid"], Is.EqualTo("541037e2-9f6a-466c-b56f-a09f81f36576"));
+            Assert.That((int) ordinalScale["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) ordinalScale["classKind"], Is.EqualTo("OrdinalScale"));
 
             Assert.IsTrue((bool) ordinalScale["useShortNameValues"]);
-            Assert.AreEqual("Test Ordinal Scale", (string) ordinalScale["name"]);
-            Assert.AreEqual("TestOrdinalScale", (string) ordinalScale["shortName"]);
+            Assert.That((string) ordinalScale["name"], Is.EqualTo("Test Ordinal Scale"));
+            Assert.That((string) ordinalScale["shortName"], Is.EqualTo("TestOrdinalScale"));
 
             Assert.IsFalse((bool) ordinalScale["isDeprecated"]);
-            Assert.AreEqual("56842970-3915-4369-8712-61cfd8273ef9", (string) ordinalScale["unit"]);
+            Assert.That((string) ordinalScale["unit"], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
 
             var expectedValueDefinitions = new string[]
             {
@@ -108,13 +108,13 @@ namespace WebservicesIntegrationTests
             IList<string> valueDefinitions = valueDefinitionsArray.Select(x => (string) x).ToList();
             Assert.That(valueDefinitions, Is.EquivalentTo(expectedValueDefinitions));
 
-            Assert.AreEqual("NATURAL_NUMBER_SET", (string) ordinalScale["numberSet"]);
-            Assert.AreEqual("0", (string) ordinalScale["minimumPermissibleValue"]);
+            Assert.That((string) ordinalScale["numberSet"], Is.EqualTo("NATURAL_NUMBER_SET"));
+            Assert.That((string) ordinalScale["minimumPermissibleValue"], Is.EqualTo("0"));
             Assert.IsTrue((bool) ordinalScale["isMinimumInclusive"]);
-            Assert.AreEqual("100", (string) ordinalScale["maximumPermissibleValue"]);
+            Assert.That((string) ordinalScale["maximumPermissibleValue"], Is.EqualTo("100"));
             Assert.IsTrue((bool) ordinalScale["isMaximumInclusive"]);
-            Assert.AreEqual("positive Value Connotation", (string) ordinalScale["positiveValueConnotation"]);
-            Assert.AreEqual("negative Value Connotation", (string) ordinalScale["negativeValueConnotation"]);
+            Assert.That((string) ordinalScale["positiveValueConnotation"], Is.EqualTo("positive Value Connotation"));
+            Assert.That((string) ordinalScale["negativeValueConnotation"], Is.EqualTo("negative Value Connotation"));
 
             var expectedMappingToReferenceScales = new string[] {};
             var mappingToReferenceScalesArray = (JArray) ordinalScale["mappingToReferenceScale"];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Organization/OrganizationTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Organization/OrganizationTestFixture.cs
@@ -58,7 +58,7 @@ namespace WebservicesIntegrationTests
             // Get the response from the data-source as a JArray (JSON Array)
             var jArray = this.WebClient.GetDto(personsUri);
             
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             var siteDirectory = jArray.Single(x => (string)x[PropertyNames.Iid] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
             SiteDirectoryTestFixture.VerifyProperties(siteDirectory);
@@ -78,15 +78,15 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken organization)
         {
             // verify that the amount of returned properties 
-            Assert.AreEqual(6, organization.Children().Count());
+            Assert.That(organization.Children().Count(), Is.EqualTo(6));
 
-            Assert.AreEqual("cd22fc45-d898-4fac-85fc-fbcb7d7b12a7", (string)organization[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int)organization[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("Organization", (string)organization[PropertyNames.ClassKind]);
+            Assert.That((string)organization[PropertyNames.Iid], Is.EqualTo("cd22fc45-d898-4fac-85fc-fbcb7d7b12a7"));
+            Assert.That((int)organization[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string)organization[PropertyNames.ClassKind], Is.EqualTo("Organization"));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("Test Organization", (string)organization[PropertyNames.Name]);
-            Assert.AreEqual("TestOrganization", (string)organization[PropertyNames.ShortName]);
+            Assert.That((string)organization[PropertyNames.Name], Is.EqualTo("Test Organization"));
+            Assert.That((string)organization[PropertyNames.ShortName], Is.EqualTo("TestOrganization"));
             Assert.IsFalse((bool)organization[PropertyNames.IsDeprecated]);
         }
     }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ParameterizedCategoryRule/ParameterizedCategoryRuleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ParameterizedCategoryRule/ParameterizedCategoryRuleTestFixture.cs
@@ -86,19 +86,18 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken parameterizedCategoryRule)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(11, parameterizedCategoryRule.Children().Count());
+            Assert.That(parameterizedCategoryRule.Children().Count(), Is.EqualTo(11));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("7a6186ca-10c1-4074-bec1-4a92ce6ae59d", (string) parameterizedCategoryRule["iid"]);
-            Assert.AreEqual(1, (int) parameterizedCategoryRule["revisionNumber"]);
-            Assert.AreEqual("ParameterizedCategoryRule", (string) parameterizedCategoryRule["classKind"]);
+            Assert.That((string) parameterizedCategoryRule["iid"], Is.EqualTo("7a6186ca-10c1-4074-bec1-4a92ce6ae59d"));
+            Assert.That((int) parameterizedCategoryRule["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) parameterizedCategoryRule["classKind"], Is.EqualTo("ParameterizedCategoryRule"));
 
             Assert.IsFalse((bool) parameterizedCategoryRule["isDeprecated"]);
-            Assert.AreEqual("TestParameterizedCategoryRule", (string) parameterizedCategoryRule["name"]);
-            Assert.AreEqual("Test Parameterized Category Rule", (string) parameterizedCategoryRule["shortName"]);
+            Assert.That((string) parameterizedCategoryRule["name"], Is.EqualTo("TestParameterizedCategoryRule"));
+            Assert.That((string) parameterizedCategoryRule["shortName"], Is.EqualTo("Test Parameterized Category Rule"));
 
-            Assert.AreEqual("107fc408-7e6d-4f1a-895a-1b6a6025ac20",
-                (string) parameterizedCategoryRule["category"]);
+            Assert.That((string) parameterizedCategoryRule["category"], Is.EqualTo("107fc408-7e6d-4f1a-895a-1b6a6025ac20"));
 
             var expectedParameterTypes = new string[]
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Participant/ParticipantTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Participant/ParticipantTestFixture.cs
@@ -41,7 +41,7 @@ namespace WebservicesIntegrationTests
 
             var exception = Assert.Catch<WebException>(() => this.WebClient.PostDto(participantUri, postBody));
             var errorMessage = this.WebClient.ExtractExceptionStringFromResponse(exception.Response);
-            Assert.AreEqual(HttpStatusCode.Forbidden, ((HttpWebResponse)exception.Response).StatusCode);
+            Assert.That(((HttpWebResponse)exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
             Assert.IsTrue(errorMessage.Contains("Participant selected domain must be contained in participant domain list."));
         }
 
@@ -58,7 +58,7 @@ namespace WebservicesIntegrationTests
 
             var exception = Assert.Catch<WebException>(() => this.WebClient.PostDto(participantUri, postBody));
             var errorMessage = this.WebClient.ExtractExceptionStringFromResponse(exception.Response);
-            Assert.AreEqual(HttpStatusCode.BadRequest, ((HttpWebResponse)exception.Response).StatusCode);
+            Assert.That(((HttpWebResponse)exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
             Assert.IsTrue(errorMessage.Contains("is already a Participant in EngineeringModel"));
         }
     }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ParticipantPermission/ParticipantPermissionTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ParticipantPermission/ParticipantPermissionTestFixture.cs
@@ -41,7 +41,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(participantPermissionUri);
 
             //check if there are 24 ParticipantPermission objects 
-            Assert.AreEqual(24, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(24));
 
             ParticipantPermissionTestFixture.VerifyProperties(jArray);
         }
@@ -57,7 +57,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(participantPermissionUri);
 
             //check if there are 26 objects
-            Assert.AreEqual(26, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(26));
 
             // get a specific SiteDirectory from the result by it's unique id
             var siteDirectory = jArray.Single(x => (string) x["iid"] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
@@ -82,219 +82,219 @@ namespace WebservicesIntegrationTests
         {
             var participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "c8656ec9-3377-4ea6-9d20-825e8f6fe335");
-            Assert.AreEqual("c8656ec9-3377-4ea6-9d20-825e8f6fe335", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("c8656ec9-3377-4ea6-9d20-825e8f6fe335"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("File", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("File"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "8460a98f-6958-4caa-aa13-47b350e4bea9");
-            Assert.AreEqual("8460a98f-6958-4caa-aa13-47b350e4bea9", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("8460a98f-6958-4caa-aa13-47b350e4bea9"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("Parameter", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("Parameter"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "c3cf7ff9-4a4f-44a4-b91f-9918a12f664b");
-            Assert.AreEqual("c3cf7ff9-4a4f-44a4-b91f-9918a12f664b", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("c3cf7ff9-4a4f-44a4-b91f-9918a12f664b"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("Relationship", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("Relationship"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "8fdfec18-72d7-4e14-bcd1-5298f7594333");
-            Assert.AreEqual("8fdfec18-72d7-4e14-bcd1-5298f7594333", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("8fdfec18-72d7-4e14-bcd1-5298f7594333"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("ModelLogEntry", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ModelLogEntry"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "b380b256-8938-4dab-98c5-554cb619e81b");
-            Assert.AreEqual("b380b256-8938-4dab-98c5-554cb619e81b", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("b380b256-8938-4dab-98c5-554cb619e81b"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("Iteration", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("Iteration"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "39a2a62a-655d-45c1-8b6f-6bad372f935b");
-            Assert.AreEqual("39a2a62a-655d-45c1-8b6f-6bad372f935b", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("39a2a62a-655d-45c1-8b6f-6bad372f935b"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("ElementUsage", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ElementUsage"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "1bebf97d-114a-4baa-ba61-0f01eeb7e1ad");
-            Assert.AreEqual("1bebf97d-114a-4baa-ba61-0f01eeb7e1ad", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("1bebf97d-114a-4baa-ba61-0f01eeb7e1ad"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("RequirementsSpecification", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("RequirementsSpecification"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "72cd93f4-e8f7-446b-a369-838b5a1ecc57");
-            Assert.AreEqual("72cd93f4-e8f7-446b-a369-838b5a1ecc57", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("72cd93f4-e8f7-446b-a369-838b5a1ecc57"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("ParameterGroup", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ParameterGroup"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "4ac0b072-8d58-46e0-8073-a48013c4c5be");
-            Assert.AreEqual("4ac0b072-8d58-46e0-8073-a48013c4c5be", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("4ac0b072-8d58-46e0-8073-a48013c4c5be"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("ExternalIdentifierMap", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ExternalIdentifierMap"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "bc7a0939-d6ee-4a08-9bb5-c350755dcd0d");
-            Assert.AreEqual("bc7a0939-d6ee-4a08-9bb5-c350755dcd0d", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("bc7a0939-d6ee-4a08-9bb5-c350755dcd0d"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("RequirementsGroup", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("RequirementsGroup"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "0145d47c-2971-4f89-9dc8-2c5e0453805e");
-            Assert.AreEqual("0145d47c-2971-4f89-9dc8-2c5e0453805e", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("0145d47c-2971-4f89-9dc8-2c5e0453805e"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("ElementDefinition", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ElementDefinition"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "b9eefd51-9da8-4f3f-b67c-8259ebad3b72");
-            Assert.AreEqual("b9eefd51-9da8-4f3f-b67c-8259ebad3b72", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("b9eefd51-9da8-4f3f-b67c-8259ebad3b72"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("ParameterOverride", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ParameterOverride"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "c189f7cb-056e-4659-affa-b3ff4f6ba881");
-            Assert.AreEqual("c189f7cb-056e-4659-affa-b3ff4f6ba881", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("c189f7cb-056e-4659-affa-b3ff4f6ba881"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("NestedElement", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("NestedElement"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "dbe6a4b9-3b14-4580-8d3a-33ddf325c651");
-            Assert.AreEqual("dbe6a4b9-3b14-4580-8d3a-33ddf325c651", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("dbe6a4b9-3b14-4580-8d3a-33ddf325c651"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("Requirement", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("Requirement"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "bd276630-1d3f-45d0-9aa5-0efb9accbadb");
-            Assert.AreEqual("bd276630-1d3f-45d0-9aa5-0efb9accbadb", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("bd276630-1d3f-45d0-9aa5-0efb9accbadb"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("Publication", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("Publication"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "df41e148-e228-4f19-b15a-2b68b75891e9");
-            Assert.AreEqual("df41e148-e228-4f19-b15a-2b68b75891e9", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("df41e148-e228-4f19-b15a-2b68b75891e9"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("NestedParameter", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("NestedParameter"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "ee7a7848-90d5-4914-b258-4a00c0543db0");
-            Assert.AreEqual("ee7a7848-90d5-4914-b258-4a00c0543db0", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("ee7a7848-90d5-4914-b258-4a00c0543db0"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("CommonFileStore", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("CommonFileStore"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "ac6fe12e-fdaa-4b94-9822-312d0897f5cb");
-            Assert.AreEqual("ac6fe12e-fdaa-4b94-9822-312d0897f5cb", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("ac6fe12e-fdaa-4b94-9822-312d0897f5cb"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("ActualFiniteStateList", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ActualFiniteStateList"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "f0bb5b06-b7b1-4e67-ae02-c71d73e71d00");
-            Assert.AreEqual("f0bb5b06-b7b1-4e67-ae02-c71d73e71d00", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("f0bb5b06-b7b1-4e67-ae02-c71d73e71d00"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("PossibleFiniteStateList", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("PossibleFiniteStateList"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "7f8f6f00-1a3d-412c-a276-747306a4f961");
-            Assert.AreEqual("7f8f6f00-1a3d-412c-a276-747306a4f961", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("7f8f6f00-1a3d-412c-a276-747306a4f961"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("ParameterSubscription", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("ParameterSubscription"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "a18e23ea-77a1-481f-ad4a-b23a9022f93f");
-            Assert.AreEqual("a18e23ea-77a1-481f-ad4a-b23a9022f93f", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("a18e23ea-77a1-481f-ad4a-b23a9022f93f"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("Folder", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("Folder"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "8f3627a8-7782-4b1c-8677-e546db6965a9");
-            Assert.AreEqual("8f3627a8-7782-4b1c-8677-e546db6965a9", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("8f3627a8-7782-4b1c-8677-e546db6965a9"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("RuleVerificationList", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("RuleVerificationList"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "af6526f8-66f4-4a0b-9c49-d9ae00e97108");
-            Assert.AreEqual("af6526f8-66f4-4a0b-9c49-d9ae00e97108", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("af6526f8-66f4-4a0b-9c49-d9ae00e97108"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("DomainFileStore", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("DomainFileStore"));
 
             participantPermissionObject =
                 participantPermission.Single(x => (string) x["iid"] == "939bdada-f827-4f27-8761-ba78918431dd");
-            Assert.AreEqual("939bdada-f827-4f27-8761-ba78918431dd", (string) participantPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) participantPermissionObject["revisionNumber"]);
-            Assert.AreEqual("ParticipantPermission", (string) participantPermissionObject["classKind"]);
+            Assert.That((string) participantPermissionObject["iid"], Is.EqualTo("939bdada-f827-4f27-8761-ba78918431dd"));
+            Assert.That((int) participantPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantPermissionObject["classKind"], Is.EqualTo("ParticipantPermission"));
             Assert.IsFalse((bool) participantPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) participantPermissionObject["accessRight"]);
-            Assert.AreEqual("EngineeringModel", (string) participantPermissionObject["objectClass"]);
+            Assert.That((string) participantPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) participantPermissionObject["objectClass"], Is.EqualTo("EngineeringModel"));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ParticipantRole/ParticipantRoleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ParticipantRole/ParticipantRoleTestFixture.cs
@@ -61,7 +61,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(participantRolesUri);
 
             //check if there are only two objects
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             var siteDirectory = jArray.Single(x => (string) x["iid"] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
             SiteDirectoryTestFixture.VerifyProperties(siteDirectory);
@@ -81,15 +81,15 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken participantRole)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(10, participantRole.Children().Count());
+            Assert.That(participantRole.Children().Count(), Is.EqualTo(10));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("ee3ae5ff-ac5e-4957-bab1-7698fba2a267", (string) participantRole["iid"]);
-            Assert.AreEqual(1, (int) participantRole["revisionNumber"]);
-            Assert.AreEqual("ParticipantRole", (string) participantRole["classKind"]);
+            Assert.That((string) participantRole["iid"], Is.EqualTo("ee3ae5ff-ac5e-4957-bab1-7698fba2a267"));
+            Assert.That((int) participantRole["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) participantRole["classKind"], Is.EqualTo("ParticipantRole"));
             
-            Assert.AreEqual("Test Participant Role", (string) participantRole["name"]);
-            Assert.AreEqual("TestParticipantRole", (string) participantRole["shortName"]);
+            Assert.That((string) participantRole["name"], Is.EqualTo("Test Participant Role"));
+            Assert.That((string) participantRole["shortName"], Is.EqualTo("TestParticipantRole"));
             Assert.IsFalse((bool) participantRole["isDeprecated"]);
 
             var expectedAliases = new string[] {};

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Person/PersonTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Person/PersonTestFixture.cs
@@ -61,7 +61,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(personsUri);
 
             // assert that the returned person count = 2
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             // get a specific SiteDirectory from the result by it's unique id
             var siteDirectory = jArray.Single(x => (string) x[PropertyNames.Iid] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
@@ -83,15 +83,15 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(uri, postBody);
 
             // check if there are 2 objects
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             // get a specific SiteDirectory from the result by it's unique id
             var siteDirectory = jArray.Single(x => (string)x[PropertyNames.Iid] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
-            Assert.AreEqual(2, (int)siteDirectory[PropertyNames.RevisionNumber]);
+            Assert.That((int)siteDirectory[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // get a specific Person from the result by it's unique id
             var person = jArray.Single(x => (string)x[PropertyNames.Iid] == "77791b12-4c2c-4499-93fa-869df3692d22");
-            Assert.AreEqual(2, (int)person[PropertyNames.RevisionNumber]);
+            Assert.That((int)person[PropertyNames.RevisionNumber], Is.EqualTo(2));
             var expectedTelephoneNumbers = new string[]
                                                {
                                                    "0367167c-80cb-4f99-a24b-e713efd15436"
@@ -145,21 +145,21 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(uri, postBody);
 
             // check if there are 2 objects
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             // get a specific SiteDirectory from the result by it's unique id
             var siteDirectory = jArray.Single(x => (string)x[PropertyNames.Iid] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
             
             // verify that the amount of returned properties 
-            Assert.AreEqual(19, siteDirectory.Children().Count());
+            Assert.That(siteDirectory.Children().Count(), Is.EqualTo(19));
 
-            Assert.AreEqual("f13de6f8-b03a-46e7-a492-53b2f260f294", (string)siteDirectory[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)siteDirectory[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SiteDirectory", (string)siteDirectory[PropertyNames.ClassKind]);
-            Assert.AreEqual("Test Site Directory", (string)siteDirectory[PropertyNames.Name]);
-            Assert.AreEqual("TEST-SiteDir", (string)siteDirectory[PropertyNames.ShortName]);
-            Assert.AreEqual("ee3ae5ff-ac5e-4957-bab1-7698fba2a267", (string)siteDirectory[PropertyNames.DefaultParticipantRole]);
-            Assert.AreEqual("2428f4d9-f26d-4112-9d56-1c940748df69", (string)siteDirectory[PropertyNames.DefaultPersonRole]);
+            Assert.That((string)siteDirectory[PropertyNames.Iid], Is.EqualTo("f13de6f8-b03a-46e7-a492-53b2f260f294"));
+            Assert.That((int)siteDirectory[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string)siteDirectory[PropertyNames.ClassKind], Is.EqualTo("SiteDirectory"));
+            Assert.That((string)siteDirectory[PropertyNames.Name], Is.EqualTo("Test Site Directory"));
+            Assert.That((string)siteDirectory[PropertyNames.ShortName], Is.EqualTo("TEST-SiteDir"));
+            Assert.That((string)siteDirectory[PropertyNames.DefaultParticipantRole], Is.EqualTo("ee3ae5ff-ac5e-4957-bab1-7698fba2a267"));
+            Assert.That((string)siteDirectory[PropertyNames.DefaultPersonRole], Is.EqualTo("2428f4d9-f26d-4112-9d56-1c940748df69"));
 
             var expectedOrganizations = new string[] { "cd22fc45-d898-4fac-85fc-fbcb7d7b12a7" };
             var organizationArray = (JArray)siteDirectory[PropertyNames.Organization];
@@ -222,21 +222,21 @@ namespace WebservicesIntegrationTests
             // get a specific Person from the result by it's unique id
             var person = jArray.Single(x => (string)x[PropertyNames.Iid] == "01a6d208-7bb5-4855-a6fb-eb3d03f1337b");
             // verify that the amount of returned properties 
-            Assert.AreEqual(18, person.Children().Count());
+            Assert.That(person.Children().Count(), Is.EqualTo(18));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("01a6d208-7bb5-4855-a6fb-eb3d03f1337b", (string)person[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)person[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("no", (string)person[PropertyNames.GivenName]);
-            Assert.AreEqual("role", (string)person[PropertyNames.Surname]);
-            Assert.AreEqual(null, (string)person[PropertyNames.OrganizationalUnit]);
-            Assert.AreEqual(null, (string)person[PropertyNames.Organization]);
-            Assert.AreEqual(null, (string)person[PropertyNames.DefaultDomain]);
+            Assert.That((string)person[PropertyNames.Iid], Is.EqualTo("01a6d208-7bb5-4855-a6fb-eb3d03f1337b"));
+            Assert.That((int)person[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string)person[PropertyNames.GivenName], Is.EqualTo("no"));
+            Assert.That((string)person[PropertyNames.Surname], Is.EqualTo("role"));
+            Assert.That((string)person[PropertyNames.OrganizationalUnit], Is.EqualTo(null));
+            Assert.That((string)person[PropertyNames.Organization], Is.EqualTo(null));
+            Assert.That((string)person[PropertyNames.DefaultDomain], Is.EqualTo(null));
             Assert.IsFalse((bool)person[PropertyNames.IsActive]);
-            Assert.AreEqual(null, (string)person[PropertyNames.Role]);
-            Assert.AreEqual(null, (string)person[PropertyNames.DefaultEmailAddress]);
-            Assert.AreEqual(null, (string)person[PropertyNames.DefaultTelephoneNumber]);
-            Assert.AreEqual("norole", (string)person[PropertyNames.ShortName]);
+            Assert.That((string)person[PropertyNames.Role], Is.EqualTo(null));
+            Assert.That((string)person[PropertyNames.DefaultEmailAddress], Is.EqualTo(null));
+            Assert.That((string)person[PropertyNames.DefaultTelephoneNumber], Is.EqualTo(null));
+            Assert.That((string)person[PropertyNames.ShortName], Is.EqualTo("norole"));
             Assert.IsFalse((bool)person[PropertyNames.IsDeprecated]);
 
             var expectedEmailAddresses = new string[]{};
@@ -292,14 +292,14 @@ namespace WebservicesIntegrationTests
 
             this.CreateNewWebClientForUser(personWithNullPassword[PropertyNames.ShortName].ToString(), null);
             var exception = Assert.Catch<WebException>(() => this.WebClient.GetDto(personWithNullPasswordUri));
-            Assert.AreEqual(HttpStatusCode.Unauthorized, ((HttpWebResponse)exception.Response).StatusCode);
+            Assert.That(((HttpWebResponse)exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
 
             var personWithEmptyPasswordUri = new Uri($"{this.Settings.Hostname}/SiteDirectory/f13de6f8-b03a-46e7-a492-53b2f260f294/person/01a6d208-7bb5-4855-a6fb-eb3d03f1337c");
             
             this.CreateNewWebClientForUser(personWithEmptyPassword[PropertyNames.ShortName].ToString(), "");
             exception = Assert.Catch<WebException>(() => this.WebClient.GetDto(personWithEmptyPasswordUri));
             var errorMessage = this.WebClient.ExtractExceptionStringFromResponse(exception.Response);
-            Assert.AreEqual(HttpStatusCode.NotFound, ((HttpWebResponse)exception.Response).StatusCode);
+            Assert.That(((HttpWebResponse)exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
             Assert.IsTrue(errorMessage.Contains("SiteDirectory f13de6f8-b03a-46e7-a492-53b2f260f294 not found"));
 
             var personWithPasswordUri = new Uri($"{this.Settings.Hostname}/SiteDirectory/f13de6f8-b03a-46e7-a492-53b2f260f294/person/01a6d208-7bb5-4855-a6fb-eb3d03f1337d");
@@ -307,7 +307,7 @@ namespace WebservicesIntegrationTests
             this.CreateNewWebClientForUser(personWithPassword[PropertyNames.ShortName].ToString(), "pass");
             exception = Assert.Catch<WebException>(() => this.WebClient.GetDto(personWithPasswordUri));
             errorMessage = this.WebClient.ExtractExceptionStringFromResponse(exception.Response);
-            Assert.AreEqual(HttpStatusCode.NotFound, ((HttpWebResponse) exception.Response).StatusCode);
+            Assert.That(((HttpWebResponse) exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
             Assert.IsTrue(errorMessage.Contains("SiteDirectory f13de6f8-b03a-46e7-a492-53b2f260f294 not found"));
         }
 
@@ -328,16 +328,16 @@ namespace WebservicesIntegrationTests
             Assert.That((int)person[PropertyNames.RevisionNumber], Is.EqualTo(1));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("John", (string) person[PropertyNames.GivenName]);
-            Assert.AreEqual("Doe", (string) person[PropertyNames.Surname]);
-            Assert.AreEqual("", (string) person[PropertyNames.OrganizationalUnit]);
-            Assert.AreEqual(null, (string) person[PropertyNames.Organization]);
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) person[PropertyNames.DefaultDomain]);
+            Assert.That((string) person[PropertyNames.GivenName], Is.EqualTo("John"));
+            Assert.That((string) person[PropertyNames.Surname], Is.EqualTo("Doe"));
+            Assert.That((string) person[PropertyNames.OrganizationalUnit], Is.EqualTo(""));
+            Assert.That((string) person[PropertyNames.Organization], Is.EqualTo(null));
+            Assert.That((string) person[PropertyNames.DefaultDomain], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
             Assert.IsTrue((bool) person[PropertyNames.IsActive]);
-            Assert.AreEqual("2428f4d9-f26d-4112-9d56-1c940748df69", (string) person[PropertyNames.Role]);
-            Assert.AreEqual(null, (string) person[PropertyNames.DefaultEmailAddress]);
-            Assert.AreEqual(null, (string) person[PropertyNames.DefaultTelephoneNumber]);
-            Assert.AreEqual("admin", (string) person[PropertyNames.ShortName]);
+            Assert.That((string) person[PropertyNames.Role], Is.EqualTo("2428f4d9-f26d-4112-9d56-1c940748df69"));
+            Assert.That((string) person[PropertyNames.DefaultEmailAddress], Is.EqualTo(null));
+            Assert.That((string) person[PropertyNames.DefaultTelephoneNumber], Is.EqualTo(null));
+            Assert.That((string) person[PropertyNames.ShortName], Is.EqualTo("admin"));
             Assert.IsFalse((bool) person[PropertyNames.IsDeprecated]);
 
             // verify that there are 2 emailAddresses for this person
@@ -376,7 +376,7 @@ namespace WebservicesIntegrationTests
             var uri = new Uri($"{this.Settings.Hostname}/SiteDirectory");
 
             var exception = Assert.Catch<WebException>(() => this.WebClient.GetDto(uri));
-            Assert.AreEqual(HttpStatusCode.Forbidden, ((HttpWebResponse)exception.Response).StatusCode);
+            Assert.That(((HttpWebResponse)exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
         }
 
         [Test]
@@ -389,7 +389,7 @@ namespace WebservicesIntegrationTests
             var uri = new Uri($"{this.Settings.Hostname}/SiteDirectory");
 
             var exception = Assert.Catch<WebException>(() => this.WebClient.GetDto(uri));
-            Assert.AreEqual(HttpStatusCode.Forbidden, ((HttpWebResponse)exception.Response).StatusCode);
+            Assert.That(((HttpWebResponse)exception.Response).StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
         }
 
         [Test]

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/PersonPermission/PersonPermissionTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/PersonPermission/PersonPermissionTestFixture.cs
@@ -41,7 +41,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(personPermissionUri);
 
             //check if there are 15 PersonPermission objects 
-            Assert.AreEqual(15, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(15));
 
             PersonPermissionTestFixture.VerifyProperties(jArray);
         }
@@ -57,7 +57,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(personPermissionUri);
 
             //check if there are 17 objects
-            Assert.AreEqual(17, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(17));
 
             // get a specific SiteDirectory from the result by it's unique id
             var siteDirectory = jArray.Single(x => (string) x["iid"] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
@@ -81,124 +81,124 @@ namespace WebservicesIntegrationTests
         {
             // assert that all objects are what is expected
             var personPermissionObject = personPermission.Single(x => (string) x["iid"] == "9211fa6a-ea92-43fc-bf2e-799ffd4b05ac");
-            Assert.AreEqual("9211fa6a-ea92-43fc-bf2e-799ffd4b05ac", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("9211fa6a-ea92-43fc-bf2e-799ffd4b05ac"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("ModelReferenceDataLibrary", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("ModelReferenceDataLibrary"));
 
             personPermissionObject = personPermission.Single(x => (string) x["iid"] == "a59e0ad9-bde7-4aeb-9871-e440380c44ed");
-            Assert.AreEqual("a59e0ad9-bde7-4aeb-9871-e440380c44ed", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("a59e0ad9-bde7-4aeb-9871-e440380c44ed"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("DomainOfExpertiseGroup", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("DomainOfExpertiseGroup"));
 
             personPermissionObject = personPermission.Single(x => (string) x["iid"] == "47b4f696-cbe6-411b-b0dd-1550207aa798");
-            Assert.AreEqual("47b4f696-cbe6-411b-b0dd-1550207aa798", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("47b4f696-cbe6-411b-b0dd-1550207aa798"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("Participant", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("Participant"));
 
             personPermissionObject = personPermission.Single(x => (string) x["iid"] == "007e23c2-62c4-459d-8cb1-499d9d014bdc");
-            Assert.AreEqual("007e23c2-62c4-459d-8cb1-499d9d014bdc", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("007e23c2-62c4-459d-8cb1-499d9d014bdc"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("SiteDirectory", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("SiteDirectory"));
 
             personPermissionObject = personPermission.Single(x => (string) x["iid"] == "0ec4ea88-3d84-411c-9a4a-0b1fb546281e");
-            Assert.AreEqual("0ec4ea88-3d84-411c-9a4a-0b1fb546281e", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("0ec4ea88-3d84-411c-9a4a-0b1fb546281e"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("ParticipantPermission", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("ParticipantPermission"));
 
             personPermissionObject = personPermission.Single(x => (string) x["iid"] == "163e6bc3-4639-4204-9a5f-4266baafd25f");
-            Assert.AreEqual("163e6bc3-4639-4204-9a5f-4266baafd25f", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("163e6bc3-4639-4204-9a5f-4266baafd25f"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("PersonPermission"));
 
             personPermissionObject = personPermission.Single(x => (string) x["iid"] == "c5c23adb-82d6-4d6e-9192-183dbd67e022");
-            Assert.AreEqual("c5c23adb-82d6-4d6e-9192-183dbd67e022", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("c5c23adb-82d6-4d6e-9192-183dbd67e022"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("Person", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("Person"));
 
             personPermissionObject = personPermission.Single(x => (string) x["iid"] == "272c94f3-8fe4-44c4-a915-616a0d93db26");
-            Assert.AreEqual("272c94f3-8fe4-44c4-a915-616a0d93db26", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("272c94f3-8fe4-44c4-a915-616a0d93db26"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("IterationSetup", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("IterationSetup"));
 
             personPermissionObject = personPermission.Single(x => (string) x["iid"] == "6d336a9b-c4c3-44aa-8e96-17d9f626f3d7");
-            Assert.AreEqual("6d336a9b-c4c3-44aa-8e96-17d9f626f3d7", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("6d336a9b-c4c3-44aa-8e96-17d9f626f3d7"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("EngineeringModelSetup", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("EngineeringModelSetup"));
 
             personPermissionObject = personPermission.Single(x => (string) x["iid"] == "db0e0a1d-c182-4c49-b375-abacfb77b5a5");
-            Assert.AreEqual("db0e0a1d-c182-4c49-b375-abacfb77b5a5", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("db0e0a1d-c182-4c49-b375-abacfb77b5a5"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("SiteReferenceDataLibrary", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("SiteReferenceDataLibrary"));
 
             personPermissionObject = personPermission.Single(x => (string) x["iid"] == "9108f724-fa36-49c2-a589-e5e3f1e98be1");
-            Assert.AreEqual("9108f724-fa36-49c2-a589-e5e3f1e98be1", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("9108f724-fa36-49c2-a589-e5e3f1e98be1"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("DomainOfExpertise", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("DomainOfExpertise"));
 
             personPermissionObject = personPermission.Single(x => (string) x["iid"] == "1f56c492-8ce5-44a0-82eb-d515ac8653f7");
-            Assert.AreEqual("1f56c492-8ce5-44a0-82eb-d515ac8653f7", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("1f56c492-8ce5-44a0-82eb-d515ac8653f7"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("Organization", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("Organization"));
 
             personPermissionObject = personPermission.Single(x => (string) x["iid"] == "e2c74973-a0e0-4212-96fe-4b0a236a07a0");
-            Assert.AreEqual("e2c74973-a0e0-4212-96fe-4b0a236a07a0", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("e2c74973-a0e0-4212-96fe-4b0a236a07a0"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("ParticipantRole", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("ParticipantRole"));
 
             personPermissionObject = personPermission.Single(x => (string) x["iid"] == "fc37edbf-c4e3-4902-bae5-533631f36e29");
-            Assert.AreEqual("fc37edbf-c4e3-4902-bae5-533631f36e29", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("fc37edbf-c4e3-4902-bae5-533631f36e29"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("PersonRole", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("PersonRole"));
 
             personPermissionObject = personPermission.Single(x => (string) x["iid"] == "98b924e2-3709-4b2c-b304-b74e3eab13af");
-            Assert.AreEqual("98b924e2-3709-4b2c-b304-b74e3eab13af", (string) personPermissionObject["iid"]);
-            Assert.AreEqual(1, (int) personPermissionObject["revisionNumber"]);
-            Assert.AreEqual("PersonPermission", (string) personPermissionObject["classKind"]);
+            Assert.That((string) personPermissionObject["iid"], Is.EqualTo("98b924e2-3709-4b2c-b304-b74e3eab13af"));
+            Assert.That((int) personPermissionObject["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personPermissionObject["classKind"], Is.EqualTo("PersonPermission"));
             Assert.IsFalse((bool) personPermissionObject["isDeprecated"]);
-            Assert.AreEqual("MODIFY", (string) personPermissionObject["accessRight"]);
-            Assert.AreEqual("SiteLogEntry", (string) personPermissionObject["objectClass"]);
+            Assert.That((string) personPermissionObject["accessRight"], Is.EqualTo("MODIFY"));
+            Assert.That((string) personPermissionObject["objectClass"], Is.EqualTo("SiteLogEntry"));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/PersonRole/PersonRoleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/PersonRole/PersonRoleTestFixture.cs
@@ -65,7 +65,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(personRolesUri);
 
             //check if there are only two objects
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             var siteDirectory = jArray.Single(x => (string)x["iid"] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
             SiteDirectoryTestFixture.VerifyProperties(siteDirectory);
@@ -85,16 +85,16 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken personRole)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(10, personRole.Children().Count());
+            Assert.That(personRole.Children().Count(), Is.EqualTo(10));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("2428f4d9-f26d-4112-9d56-1c940748df69", (string) personRole["iid"]);
-            Assert.AreEqual(1, (int) personRole["revisionNumber"]);
-            Assert.AreEqual("PersonRole", (string) personRole["classKind"]);
+            Assert.That((string) personRole["iid"], Is.EqualTo("2428f4d9-f26d-4112-9d56-1c940748df69"));
+            Assert.That((int) personRole["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) personRole["classKind"], Is.EqualTo("PersonRole"));
 
 
-            Assert.AreEqual("Test Person Role", (string) personRole["name"]);
-            Assert.AreEqual("TestPersonRole", (string) personRole["shortName"]);
+            Assert.That((string) personRole["name"], Is.EqualTo("Test Person Role"));
+            Assert.That((string) personRole["shortName"], Is.EqualTo("TestPersonRole"));
             Assert.IsFalse((bool) personRole["isDeprecated"]);
 
             var expectedAliases = new string[] {};

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/PrefixedUnit/PrefixedUnitTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/PrefixedUnit/PrefixedUnitTestFixture.cs
@@ -90,15 +90,15 @@ namespace WebservicesIntegrationTests
             var siteDirectory = jArray.Single(x => (string)x[PropertyNames.Iid] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
 
             // verify that the amount of returned properties 
-            Assert.AreEqual(19, siteDirectory.Children().Count());
+            Assert.That(siteDirectory.Children().Count(), Is.EqualTo(19));
 
-            Assert.AreEqual("f13de6f8-b03a-46e7-a492-53b2f260f294", (string)siteDirectory[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)siteDirectory[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SiteDirectory", (string)siteDirectory[PropertyNames.ClassKind]);
-            Assert.AreEqual("Test Site Directory", (string)siteDirectory[PropertyNames.Name]);
-            Assert.AreEqual("TEST-SiteDir", (string)siteDirectory[PropertyNames.ShortName]);
-            Assert.AreEqual("ee3ae5ff-ac5e-4957-bab1-7698fba2a267", (string)siteDirectory[PropertyNames.DefaultParticipantRole]);
-            Assert.AreEqual("2428f4d9-f26d-4112-9d56-1c940748df69", (string)siteDirectory[PropertyNames.DefaultPersonRole]);
+            Assert.That((string)siteDirectory[PropertyNames.Iid], Is.EqualTo("f13de6f8-b03a-46e7-a492-53b2f260f294"));
+            Assert.That((int)siteDirectory[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string)siteDirectory[PropertyNames.ClassKind], Is.EqualTo("SiteDirectory"));
+            Assert.That((string)siteDirectory[PropertyNames.Name], Is.EqualTo("Test Site Directory"));
+            Assert.That((string)siteDirectory[PropertyNames.ShortName], Is.EqualTo("TEST-SiteDir"));
+            Assert.That((string)siteDirectory[PropertyNames.DefaultParticipantRole], Is.EqualTo("ee3ae5ff-ac5e-4957-bab1-7698fba2a267"));
+            Assert.That((string)siteDirectory[PropertyNames.DefaultPersonRole], Is.EqualTo("2428f4d9-f26d-4112-9d56-1c940748df69"));
 
             var expectedOrganizations = new string[] { "cd22fc45-d898-4fac-85fc-fbcb7d7b12a7" };
             var organizationArray = (JArray)siteDirectory[PropertyNames.Organization];
@@ -162,16 +162,16 @@ namespace WebservicesIntegrationTests
             var siteReferenceDataLibrary = jArray.Single(x => (string)x[PropertyNames.Iid] == "c454c687-ba3e-44c4-86bc-44544b2c7880");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(22, siteReferenceDataLibrary.Children().Count());
+            Assert.That(siteReferenceDataLibrary.Children().Count(), Is.EqualTo(22));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("c454c687-ba3e-44c4-86bc-44544b2c7880", (string)siteReferenceDataLibrary[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)siteReferenceDataLibrary[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SiteReferenceDataLibrary", (string)siteReferenceDataLibrary[PropertyNames.ClassKind]);
+            Assert.That((string)siteReferenceDataLibrary[PropertyNames.Iid], Is.EqualTo("c454c687-ba3e-44c4-86bc-44544b2c7880"));
+            Assert.That((int)siteReferenceDataLibrary[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string)siteReferenceDataLibrary[PropertyNames.ClassKind], Is.EqualTo("SiteReferenceDataLibrary"));
 
             Assert.IsFalse((bool)siteReferenceDataLibrary[PropertyNames.IsDeprecated]);
-            Assert.AreEqual("Test Reference Data Library", (string)siteReferenceDataLibrary[PropertyNames.Name]);
-            Assert.AreEqual("TestRDL", (string)siteReferenceDataLibrary[PropertyNames.ShortName]);
+            Assert.That((string)siteReferenceDataLibrary[PropertyNames.Name], Is.EqualTo("Test Reference Data Library"));
+            Assert.That((string)siteReferenceDataLibrary[PropertyNames.ShortName], Is.EqualTo("TestRDL"));
 
             var expectedAliases = new string[] { };
             var aliasesArray = (JArray)siteReferenceDataLibrary[PropertyNames.Alias];
@@ -316,16 +316,16 @@ namespace WebservicesIntegrationTests
             var prefixedUnit = jArray.Single(x => (string)x[PropertyNames.Iid] == "9fb8085f-a7d3-4068-95e3-686e4d954d1c");
             
             // verify the amount of returned properties 
-            Assert.AreEqual(9, prefixedUnit.Children().Count());
+            Assert.That(prefixedUnit.Children().Count(), Is.EqualTo(9));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("9fb8085f-a7d3-4068-95e3-686e4d954d1c", (string)prefixedUnit[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)prefixedUnit[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("PrefixedUnit", (string)prefixedUnit[PropertyNames.ClassKind]);
+            Assert.That((string)prefixedUnit[PropertyNames.Iid], Is.EqualTo("9fb8085f-a7d3-4068-95e3-686e4d954d1c"));
+            Assert.That((int)prefixedUnit[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string)prefixedUnit[PropertyNames.ClassKind], Is.EqualTo("PrefixedUnit"));
 
             Assert.IsFalse((bool)prefixedUnit[PropertyNames.IsDeprecated]);
-            Assert.AreEqual("efa6380d-9508-4f3d-9b43-6ed33125b780", (string)prefixedUnit[PropertyNames.Prefix]);
-            Assert.AreEqual("56842970-3915-4369-8712-61cfd8273ef9", (string)prefixedUnit[PropertyNames.ReferenceUnit]);
+            Assert.That((string)prefixedUnit[PropertyNames.Prefix], Is.EqualTo("efa6380d-9508-4f3d-9b43-6ed33125b780"));
+            Assert.That((string)prefixedUnit[PropertyNames.ReferenceUnit], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
 
             var expectedPrefixedUnitAliases = new string[] { };
             var prefixedUnitAliasesArray = (JArray)prefixedUnit[PropertyNames.Alias];
@@ -353,16 +353,16 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken prefixedUnit)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(9, prefixedUnit.Children().Count());
+            Assert.That(prefixedUnit.Children().Count(), Is.EqualTo(9));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("0f69c1f9-7896-45fc-830c-1e336d22a64a", (string) prefixedUnit["iid"]);
-            Assert.AreEqual(1, (int) prefixedUnit["revisionNumber"]);
-            Assert.AreEqual("PrefixedUnit", (string) prefixedUnit["classKind"]);
+            Assert.That((string) prefixedUnit["iid"], Is.EqualTo("0f69c1f9-7896-45fc-830c-1e336d22a64a"));
+            Assert.That((int) prefixedUnit["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) prefixedUnit["classKind"], Is.EqualTo("PrefixedUnit"));
 
             Assert.IsFalse((bool) prefixedUnit["isDeprecated"]);
-            Assert.AreEqual("efa6380d-9508-4f3d-9b43-6ed33125b780", (string) prefixedUnit["prefix"]);
-            Assert.AreEqual("56842970-3915-4369-8712-61cfd8273ef9", (string) prefixedUnit["referenceUnit"]);
+            Assert.That((string) prefixedUnit["prefix"], Is.EqualTo("efa6380d-9508-4f3d-9b43-6ed33125b780"));
+            Assert.That((string) prefixedUnit["referenceUnit"], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
 
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) prefixedUnit["alias"];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/QuantityKind/QuantityKindTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/QuantityKind/QuantityKindTestFixture.cs
@@ -45,15 +45,15 @@ namespace WebservicesIntegrationTests
             var siteDirectory = jArray.Single(x => (string) x[PropertyNames.Iid] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
 
             // verify that the amount of returned properties 
-            Assert.AreEqual(19, siteDirectory.Children().Count());
+            Assert.That(siteDirectory.Children().Count(), Is.EqualTo(19));
 
-            Assert.AreEqual("f13de6f8-b03a-46e7-a492-53b2f260f294", (string) siteDirectory[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) siteDirectory[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SiteDirectory", (string) siteDirectory[PropertyNames.ClassKind]);
-            Assert.AreEqual("Test Site Directory", (string) siteDirectory[PropertyNames.Name]);
-            Assert.AreEqual("TEST-SiteDir", (string) siteDirectory[PropertyNames.ShortName]);
-            Assert.AreEqual("ee3ae5ff-ac5e-4957-bab1-7698fba2a267", (string) siteDirectory[PropertyNames.DefaultParticipantRole]);
-            Assert.AreEqual("2428f4d9-f26d-4112-9d56-1c940748df69", (string) siteDirectory[PropertyNames.DefaultPersonRole]);
+            Assert.That((string) siteDirectory[PropertyNames.Iid], Is.EqualTo("f13de6f8-b03a-46e7-a492-53b2f260f294"));
+            Assert.That((int) siteDirectory[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) siteDirectory[PropertyNames.ClassKind], Is.EqualTo("SiteDirectory"));
+            Assert.That((string) siteDirectory[PropertyNames.Name], Is.EqualTo("Test Site Directory"));
+            Assert.That((string) siteDirectory[PropertyNames.ShortName], Is.EqualTo("TEST-SiteDir"));
+            Assert.That((string) siteDirectory[PropertyNames.DefaultParticipantRole], Is.EqualTo("ee3ae5ff-ac5e-4957-bab1-7698fba2a267"));
+            Assert.That((string) siteDirectory[PropertyNames.DefaultPersonRole], Is.EqualTo("2428f4d9-f26d-4112-9d56-1c940748df69"));
 
             var expectedOrganizations = new string[] { "cd22fc45-d898-4fac-85fc-fbcb7d7b12a7" };
             var organizationArray = (JArray) siteDirectory[PropertyNames.Organization];
@@ -119,16 +119,16 @@ namespace WebservicesIntegrationTests
             var siteReferenceDataLibrary = jArray.Single(x => (string) x[PropertyNames.Iid] == "c454c687-ba3e-44c4-86bc-44544b2c7880");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(22, siteReferenceDataLibrary.Children().Count());
+            Assert.That(siteReferenceDataLibrary.Children().Count(), Is.EqualTo(22));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("c454c687-ba3e-44c4-86bc-44544b2c7880", (string) siteReferenceDataLibrary[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) siteReferenceDataLibrary[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SiteReferenceDataLibrary", (string) siteReferenceDataLibrary[PropertyNames.ClassKind]);
+            Assert.That((string) siteReferenceDataLibrary[PropertyNames.Iid], Is.EqualTo("c454c687-ba3e-44c4-86bc-44544b2c7880"));
+            Assert.That((int) siteReferenceDataLibrary[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) siteReferenceDataLibrary[PropertyNames.ClassKind], Is.EqualTo("SiteReferenceDataLibrary"));
 
             Assert.IsFalse((bool) siteReferenceDataLibrary[PropertyNames.IsDeprecated]);
-            Assert.AreEqual("Test Reference Data Library", (string) siteReferenceDataLibrary[PropertyNames.Name]);
-            Assert.AreEqual("TestRDL", (string) siteReferenceDataLibrary[PropertyNames.ShortName]);
+            Assert.That((string) siteReferenceDataLibrary[PropertyNames.Name], Is.EqualTo("Test Reference Data Library"));
+            Assert.That((string) siteReferenceDataLibrary[PropertyNames.ShortName], Is.EqualTo("TestRDL"));
 
             var expectedAliases = new string[] { };
             var aliasesArray = (JArray) siteReferenceDataLibrary[PropertyNames.Alias];
@@ -291,17 +291,17 @@ namespace WebservicesIntegrationTests
             var derivedQuantityKind = jArray.Single(x => (string) x[PropertyNames.Iid] == "c36e050a-b4f9-4567-b29d-67af9216878e");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(15, derivedQuantityKind.Children().Count());
+            Assert.That(derivedQuantityKind.Children().Count(), Is.EqualTo(15));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("c36e050a-b4f9-4567-b29d-67af9216878e", (string) derivedQuantityKind[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) derivedQuantityKind[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("DerivedQuantityKind", (string) derivedQuantityKind[PropertyNames.ClassKind]);
-            Assert.AreEqual("Test Derived QuantityKind", (string) derivedQuantityKind[PropertyNames.Name]);
-            Assert.AreEqual("TestDerivedQuantityKind", (string) derivedQuantityKind[PropertyNames.ShortName]);
-            Assert.AreEqual("testSymbol", (string) derivedQuantityKind[PropertyNames.Symbol]);
-            Assert.AreEqual("testQuantityDimensionSymbol", (string) derivedQuantityKind[PropertyNames.QuantityDimensionSymbol]);
-            Assert.AreEqual("53e82aeb-c42c-475c-b6bf-a102af883471", (string) derivedQuantityKind[PropertyNames.DefaultScale]);
+            Assert.That((string) derivedQuantityKind[PropertyNames.Iid], Is.EqualTo("c36e050a-b4f9-4567-b29d-67af9216878e"));
+            Assert.That((int) derivedQuantityKind[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) derivedQuantityKind[PropertyNames.ClassKind], Is.EqualTo("DerivedQuantityKind"));
+            Assert.That((string) derivedQuantityKind[PropertyNames.Name], Is.EqualTo("Test Derived QuantityKind"));
+            Assert.That((string) derivedQuantityKind[PropertyNames.ShortName], Is.EqualTo("TestDerivedQuantityKind"));
+            Assert.That((string) derivedQuantityKind[PropertyNames.Symbol], Is.EqualTo("testSymbol"));
+            Assert.That((string) derivedQuantityKind[PropertyNames.QuantityDimensionSymbol], Is.EqualTo("testQuantityDimensionSymbol"));
+            Assert.That((string) derivedQuantityKind[PropertyNames.DefaultScale], Is.EqualTo("53e82aeb-c42c-475c-b6bf-a102af883471"));
             Assert.IsFalse((bool) derivedQuantityKind[PropertyNames.IsDeprecated]);
 
             var expectedQuantityKindFactors = new List<OrderedItem>
@@ -344,17 +344,17 @@ namespace WebservicesIntegrationTests
                 jArray.Single(x => (string) x[PropertyNames.Iid] == "199bec0a-661d-408c-8ca7-718c636c5681");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(14, simpleQuantityKind.Children().Count());
+            Assert.That(simpleQuantityKind.Children().Count(), Is.EqualTo(14));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("199bec0a-661d-408c-8ca7-718c636c5681", (string) simpleQuantityKind[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) simpleQuantityKind[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SimpleQuantityKind", (string) simpleQuantityKind[PropertyNames.ClassKind]);
-            Assert.AreEqual("Test Simple QuantityKind", (string) simpleQuantityKind[PropertyNames.Name]);
-            Assert.AreEqual("TestSimpleQuantityKind", (string) simpleQuantityKind[PropertyNames.ShortName]);
-            Assert.AreEqual("testSymbol", (string) simpleQuantityKind[PropertyNames.Symbol]);
-            Assert.AreEqual("testQuantityDimensionSymbol", (string) simpleQuantityKind[PropertyNames.QuantityDimensionSymbol]);
-            Assert.AreEqual("53e82aeb-c42c-475c-b6bf-a102af883471", (string) simpleQuantityKind[PropertyNames.DefaultScale]);
+            Assert.That((string) simpleQuantityKind[PropertyNames.Iid], Is.EqualTo("199bec0a-661d-408c-8ca7-718c636c5681"));
+            Assert.That((int) simpleQuantityKind[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) simpleQuantityKind[PropertyNames.ClassKind], Is.EqualTo("SimpleQuantityKind"));
+            Assert.That((string) simpleQuantityKind[PropertyNames.Name], Is.EqualTo("Test Simple QuantityKind"));
+            Assert.That((string) simpleQuantityKind[PropertyNames.ShortName], Is.EqualTo("TestSimpleQuantityKind"));
+            Assert.That((string) simpleQuantityKind[PropertyNames.Symbol], Is.EqualTo("testSymbol"));
+            Assert.That((string) simpleQuantityKind[PropertyNames.QuantityDimensionSymbol], Is.EqualTo("testQuantityDimensionSymbol"));
+            Assert.That((string) simpleQuantityKind[PropertyNames.DefaultScale], Is.EqualTo("53e82aeb-c42c-475c-b6bf-a102af883471"));
             Assert.IsFalse((bool) simpleQuantityKind[PropertyNames.IsDeprecated]);
 
             var expectedSimpleCategories = new string[] { };
@@ -387,18 +387,18 @@ namespace WebservicesIntegrationTests
                 jArray.Single(x => (string) x[PropertyNames.Iid] == "8b8a44cd-0071-4acf-b33e-b8c3052821c5");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(15, specializedQuantityKind.Children().Count());
+            Assert.That(specializedQuantityKind.Children().Count(), Is.EqualTo(15));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("8b8a44cd-0071-4acf-b33e-b8c3052821c5", (string) specializedQuantityKind[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) specializedQuantityKind[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SpecializedQuantityKind", (string) specializedQuantityKind[PropertyNames.ClassKind]);
-            Assert.AreEqual("Test Specialized QuantityKind", (string) specializedQuantityKind[PropertyNames.Name]);
-            Assert.AreEqual("TestSpecializedQuantityKind", (string) specializedQuantityKind[PropertyNames.ShortName]);
-            Assert.AreEqual("testSymbol", (string) specializedQuantityKind[PropertyNames.Symbol]);
-            Assert.AreEqual("testQuantityDimensionSymbol", (string) specializedQuantityKind[PropertyNames.QuantityDimensionSymbol]);
-            Assert.AreEqual("199bec0a-661d-408c-8ca7-718c636c5681", (string) specializedQuantityKind[PropertyNames.General]);
-            Assert.AreEqual("53e82aeb-c42c-475c-b6bf-a102af883471", (string) specializedQuantityKind[PropertyNames.DefaultScale]);
+            Assert.That((string) specializedQuantityKind[PropertyNames.Iid], Is.EqualTo("8b8a44cd-0071-4acf-b33e-b8c3052821c5"));
+            Assert.That((int) specializedQuantityKind[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) specializedQuantityKind[PropertyNames.ClassKind], Is.EqualTo("SpecializedQuantityKind"));
+            Assert.That((string) specializedQuantityKind[PropertyNames.Name], Is.EqualTo("Test Specialized QuantityKind"));
+            Assert.That((string) specializedQuantityKind[PropertyNames.ShortName], Is.EqualTo("TestSpecializedQuantityKind"));
+            Assert.That((string) specializedQuantityKind[PropertyNames.Symbol], Is.EqualTo("testSymbol"));
+            Assert.That((string) specializedQuantityKind[PropertyNames.QuantityDimensionSymbol], Is.EqualTo("testQuantityDimensionSymbol"));
+            Assert.That((string) specializedQuantityKind[PropertyNames.General], Is.EqualTo("199bec0a-661d-408c-8ca7-718c636c5681"));
+            Assert.That((string) specializedQuantityKind[PropertyNames.DefaultScale], Is.EqualTo("53e82aeb-c42c-475c-b6bf-a102af883471"));
             Assert.IsFalse((bool) specializedQuantityKind[PropertyNames.IsDeprecated]);
 
             var expectedSpecializedCategories = new string[] { };

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/QuantityKindFactor/QuantityKindFactorTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/QuantityKindFactor/QuantityKindFactorTestFixture.cs
@@ -98,13 +98,13 @@ namespace WebservicesIntegrationTests
             Assert.That(jArray.Count, Is.EqualTo(3));
 
             var siteDirectory = jArray.Single(x => (string) x[PropertyNames.Iid] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
-            Assert.AreEqual(2, (int) siteDirectory[PropertyNames.RevisionNumber]);
+            Assert.That((int) siteDirectory[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var quantityKindFactor = jArray.Single(x => (string) x[PropertyNames.Iid] == "6b1b9a7b-8a57-412e-a823-bcc4fd8b67e9");
-            Assert.AreEqual(2, (int) quantityKindFactor[PropertyNames.RevisionNumber]);
+            Assert.That((int) quantityKindFactor[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var derivedQuantityKind = jArray.Single(x => (string) x[PropertyNames.Iid] == "74d9c38f-5ace-4f90-8841-d0f9942e9d09");
-            Assert.AreEqual(2, (int) derivedQuantityKind[PropertyNames.RevisionNumber]);
+            Assert.That((int) derivedQuantityKind[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedQuantityKindFactorArray = new List<OrderedItem> { new OrderedItem(2, "6b1b9a7b-8a57-412e-a823-bcc4fd8b67e9"), new OrderedItem(2948121, "ab7e80da-6bc9-427f-b1fb-b97faeeca4c6") };
             var quantityKindFactorArray = JsonConvert.DeserializeObject<List<OrderedItem>>(derivedQuantityKind[PropertyNames.QuantityKindFactor].ToString());
@@ -118,16 +118,16 @@ namespace WebservicesIntegrationTests
             Assert.That(jArray.Count, Is.EqualTo(4));
 
             siteDirectory = jArray.Single(x => (string) x[PropertyNames.Iid] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
-            Assert.AreEqual(3, (int) siteDirectory[PropertyNames.RevisionNumber]);
+            Assert.That((int) siteDirectory[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             quantityKindFactor = jArray.Single(x => (string) x[PropertyNames.Iid] == "6b1b9a7b-8a57-412e-a823-bcc4fd8b67e9");
-            Assert.AreEqual(3, (int) quantityKindFactor[PropertyNames.RevisionNumber]);
+            Assert.That((int) quantityKindFactor[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             var quantityKindFactor2 = jArray.Single(x => (string) x[PropertyNames.Iid] == "ab7e80da-6bc9-427f-b1fb-b97faeeca4c6");
-            Assert.AreEqual(3, (int) quantityKindFactor2[PropertyNames.RevisionNumber]);
+            Assert.That((int) quantityKindFactor2[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             derivedQuantityKind = jArray.Single(x => (string) x[PropertyNames.Iid] == "74d9c38f-5ace-4f90-8841-d0f9942e9d09");
-            Assert.AreEqual(3, (int) derivedQuantityKind[PropertyNames.RevisionNumber]);
+            Assert.That((int) derivedQuantityKind[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             expectedQuantityKindFactorArray = new List<OrderedItem> { new OrderedItem(1, "ab7e80da-6bc9-427f-b1fb-b97faeeca4c6"), new OrderedItem(3, "6b1b9a7b-8a57-412e-a823-bcc4fd8b67e9") };
             quantityKindFactorArray = JsonConvert.DeserializeObject<List<OrderedItem>>(derivedQuantityKind[PropertyNames.QuantityKindFactor].ToString());
@@ -144,14 +144,14 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken quantityKindFactor)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(5, quantityKindFactor.Children().Count());
+            Assert.That(quantityKindFactor.Children().Count(), Is.EqualTo(5));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("ab7e80da-6bc9-427f-b1fb-b97faeeca4c6", (string) quantityKindFactor[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) quantityKindFactor[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("QuantityKindFactor", (string) quantityKindFactor[PropertyNames.ClassKind]);
-            Assert.AreEqual("4f9f3d9b-f3de-4ef5-b6cb-2e22199fab0d", (string) quantityKindFactor[PropertyNames.QuantityKind]);
-            Assert.AreEqual("-1", (string) quantityKindFactor[PropertyNames.Exponent]);
+            Assert.That((string) quantityKindFactor[PropertyNames.Iid], Is.EqualTo("ab7e80da-6bc9-427f-b1fb-b97faeeca4c6"));
+            Assert.That((int) quantityKindFactor[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) quantityKindFactor[PropertyNames.ClassKind], Is.EqualTo("QuantityKindFactor"));
+            Assert.That((string) quantityKindFactor[PropertyNames.QuantityKind], Is.EqualTo("4f9f3d9b-f3de-4ef5-b6cb-2e22199fab0d"));
+            Assert.That((string) quantityKindFactor[PropertyNames.Exponent], Is.EqualTo("-1"));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/RatioScale/RatioScaleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/RatioScale/RatioScaleTestFixture.cs
@@ -86,31 +86,31 @@ namespace WebservicesIntegrationTests.Tests.SiteDirectory.RatioScale
         public static void VerifyProperties(JToken ratioScale)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(19, ratioScale.Children().Count());
+            Assert.That(ratioScale.Children().Count(), Is.EqualTo(19));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("53e82aeb-c42c-475c-b6bf-a102af883471", (string) ratioScale["iid"]);
-            Assert.AreEqual(1, (int) ratioScale["revisionNumber"]);
-            Assert.AreEqual("RatioScale", (string) ratioScale["classKind"]);
+            Assert.That((string) ratioScale["iid"], Is.EqualTo("53e82aeb-c42c-475c-b6bf-a102af883471"));
+            Assert.That((int) ratioScale["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) ratioScale["classKind"], Is.EqualTo("RatioScale"));
 
             Assert.IsFalse((bool) ratioScale["isDeprecated"]);
-            Assert.AreEqual("Test Ratio Scale", (string) ratioScale["name"]);
-            Assert.AreEqual("TestRatioScale", (string) ratioScale["shortName"]);
+            Assert.That((string) ratioScale["name"], Is.EqualTo("Test Ratio Scale"));
+            Assert.That((string) ratioScale["shortName"], Is.EqualTo("TestRatioScale"));
 
-            Assert.AreEqual("56842970-3915-4369-8712-61cfd8273ef9", (string) ratioScale["unit"]);
+            Assert.That((string) ratioScale["unit"], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
 
             var expectedValueDefinitions = new string[] {};
             var valueDefinitionsArray = (JArray) ratioScale["valueDefinition"];
             IList<string> valueDefinitions = valueDefinitionsArray.Select(x => (string) x).ToList();
             Assert.That(valueDefinitions, Is.EquivalentTo(expectedValueDefinitions));
 
-            Assert.AreEqual("REAL_NUMBER_SET", (string) ratioScale["numberSet"]);
-            Assert.IsNull((string) ratioScale["minimumPermissibleValue"]);
+            Assert.That((string) ratioScale["numberSet"], Is.EqualTo("REAL_NUMBER_SET"));
+            Assert.That((string) ratioScale["minimumPermissibleValue"], Is.Null);
             Assert.IsTrue((bool) ratioScale["isMinimumInclusive"]);
-            Assert.IsNull((string) ratioScale["maximumPermissibleValue"]);
+            Assert.That((string) ratioScale["maximumPermissibleValue"], Is.Null);
             Assert.IsTrue((bool) ratioScale["isMaximumInclusive"]);
-            Assert.IsNull((string) ratioScale["positiveValueConnotation"]);
-            Assert.IsNull((string) ratioScale["negativeValueConnotation"]);
+            Assert.That((string) ratioScale["positiveValueConnotation"], Is.Null);
+            Assert.That((string) ratioScale["negativeValueConnotation"], Is.Null);
 
             var expectedMappingToReferenceScales = new string[] {};
             var mappingToReferenceScalesArray = (JArray) ratioScale["mappingToReferenceScale"];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ReferenceSource/ReferenceSourceTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ReferenceSource/ReferenceSourceTestFixture.cs
@@ -90,15 +90,15 @@ namespace WebservicesIntegrationTests
             var siteDirectory = jArray.Single(x => (string)x[PropertyNames.Iid] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
 
             // verify that the amount of returned properties 
-            Assert.AreEqual(19, siteDirectory.Children().Count());
+            Assert.That(siteDirectory.Children().Count(), Is.EqualTo(19));
 
-            Assert.AreEqual("f13de6f8-b03a-46e7-a492-53b2f260f294", (string)siteDirectory[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)siteDirectory[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SiteDirectory", (string)siteDirectory[PropertyNames.ClassKind]);
-            Assert.AreEqual("Test Site Directory", (string)siteDirectory[PropertyNames.Name]);
-            Assert.AreEqual("TEST-SiteDir", (string)siteDirectory[PropertyNames.ShortName]);
-            Assert.AreEqual("ee3ae5ff-ac5e-4957-bab1-7698fba2a267", (string)siteDirectory[PropertyNames.DefaultParticipantRole]);
-            Assert.AreEqual("2428f4d9-f26d-4112-9d56-1c940748df69", (string)siteDirectory[PropertyNames.DefaultPersonRole]);
+            Assert.That((string)siteDirectory[PropertyNames.Iid], Is.EqualTo("f13de6f8-b03a-46e7-a492-53b2f260f294"));
+            Assert.That((int)siteDirectory[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string)siteDirectory[PropertyNames.ClassKind], Is.EqualTo("SiteDirectory"));
+            Assert.That((string)siteDirectory[PropertyNames.Name], Is.EqualTo("Test Site Directory"));
+            Assert.That((string)siteDirectory[PropertyNames.ShortName], Is.EqualTo("TEST-SiteDir"));
+            Assert.That((string)siteDirectory[PropertyNames.DefaultParticipantRole], Is.EqualTo("ee3ae5ff-ac5e-4957-bab1-7698fba2a267"));
+            Assert.That((string)siteDirectory[PropertyNames.DefaultPersonRole], Is.EqualTo("2428f4d9-f26d-4112-9d56-1c940748df69"));
 
             var expectedOrganizations = new string[] { "cd22fc45-d898-4fac-85fc-fbcb7d7b12a7" };
             var organizationArray = (JArray)siteDirectory[PropertyNames.Organization];
@@ -162,16 +162,16 @@ namespace WebservicesIntegrationTests
             var siteReferenceDataLibrary = jArray.Single(x => (string)x[PropertyNames.Iid] == "c454c687-ba3e-44c4-86bc-44544b2c7880");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(22, siteReferenceDataLibrary.Children().Count());
+            Assert.That(siteReferenceDataLibrary.Children().Count(), Is.EqualTo(22));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("c454c687-ba3e-44c4-86bc-44544b2c7880", (string)siteReferenceDataLibrary[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)siteReferenceDataLibrary[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SiteReferenceDataLibrary", (string)siteReferenceDataLibrary[PropertyNames.ClassKind]);
+            Assert.That((string)siteReferenceDataLibrary[PropertyNames.Iid], Is.EqualTo("c454c687-ba3e-44c4-86bc-44544b2c7880"));
+            Assert.That((int)siteReferenceDataLibrary[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string)siteReferenceDataLibrary[PropertyNames.ClassKind], Is.EqualTo("SiteReferenceDataLibrary"));
 
             Assert.IsFalse((bool)siteReferenceDataLibrary[PropertyNames.IsDeprecated]);
-            Assert.AreEqual("Test Reference Data Library", (string)siteReferenceDataLibrary[PropertyNames.Name]);
-            Assert.AreEqual("TestRDL", (string)siteReferenceDataLibrary[PropertyNames.ShortName]);
+            Assert.That((string)siteReferenceDataLibrary[PropertyNames.Name], Is.EqualTo("Test Reference Data Library"));
+            Assert.That((string)siteReferenceDataLibrary[PropertyNames.ShortName], Is.EqualTo("TestRDL"));
 
             var expectedAliases = new string[] { };
             var aliasesArray = (JArray)siteReferenceDataLibrary[PropertyNames.Alias];
@@ -317,24 +317,24 @@ namespace WebservicesIntegrationTests
                 jArray.Single(x => (string)x[PropertyNames.Iid] == "b46088aa-14dd-4fbc-9f45-c4acdaf6e9f5");
 
             // verify the amount of returned properties 
-            Assert.AreEqual(17, referenceSource.Children().Count());
+            Assert.That(referenceSource.Children().Count(), Is.EqualTo(17));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("b46088aa-14dd-4fbc-9f45-c4acdaf6e9f5", (string)referenceSource[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int)referenceSource[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ReferenceSource", (string)referenceSource[PropertyNames.ClassKind]);
+            Assert.That((string)referenceSource[PropertyNames.Iid], Is.EqualTo("b46088aa-14dd-4fbc-9f45-c4acdaf6e9f5"));
+            Assert.That((int)referenceSource[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string)referenceSource[PropertyNames.ClassKind], Is.EqualTo("ReferenceSource"));
 
             Assert.IsFalse((bool)referenceSource[PropertyNames.IsDeprecated]);
-            Assert.AreEqual("test referenceSource", (string)referenceSource[PropertyNames.Name]);
-            Assert.AreEqual("testReferenceSource", (string)referenceSource[PropertyNames.ShortName]);
+            Assert.That((string)referenceSource[PropertyNames.Name], Is.EqualTo("test referenceSource"));
+            Assert.That((string)referenceSource[PropertyNames.ShortName], Is.EqualTo("testReferenceSource"));
 
-            Assert.IsNull((string)referenceSource[PropertyNames.VersionIdentifier]);
-            Assert.IsNull((string)referenceSource[PropertyNames.VersionDate]);
-            Assert.AreEqual("testAuthor", (string)referenceSource[PropertyNames.Author]);
-            Assert.AreEqual(1999, (int)referenceSource[PropertyNames.PublicationYear]);
-            Assert.AreEqual("cd22fc45-d898-4fac-85fc-fbcb7d7b12a7", (string)referenceSource[PropertyNames.Publisher]);
-            Assert.AreEqual("ffd6c100-6c72-4d2a-8565-ff24bd576a89", (string)referenceSource[PropertyNames.PublishedIn]);
-            Assert.AreEqual("en-GB", (string)referenceSource[PropertyNames.Language]);
+            Assert.That((string)referenceSource[PropertyNames.VersionIdentifier], Is.Null);
+            Assert.That((string)referenceSource[PropertyNames.VersionDate], Is.Null);
+            Assert.That((string)referenceSource[PropertyNames.Author], Is.EqualTo("testAuthor"));
+            Assert.That((int)referenceSource[PropertyNames.PublicationYear], Is.EqualTo(1999));
+            Assert.That((string)referenceSource[PropertyNames.Publisher], Is.EqualTo("cd22fc45-d898-4fac-85fc-fbcb7d7b12a7"));
+            Assert.That((string)referenceSource[PropertyNames.PublishedIn], Is.EqualTo("ffd6c100-6c72-4d2a-8565-ff24bd576a89"));
+            Assert.That((string)referenceSource[PropertyNames.Language], Is.EqualTo("en-GB"));
 
             var expectedReferenceSourceCategories = new string[] { };
             var referenceSourceCategoriesArray = (JArray)referenceSource[PropertyNames.Category];
@@ -366,24 +366,24 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken referenceSource)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(17, referenceSource.Children().Count());
+            Assert.That(referenceSource.Children().Count(), Is.EqualTo(17));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("ffd6c100-6c72-4d2a-8565-ff24bd576a89", (string) referenceSource[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) referenceSource[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("ReferenceSource", (string) referenceSource[PropertyNames.ClassKind]);
+            Assert.That((string) referenceSource[PropertyNames.Iid], Is.EqualTo("ffd6c100-6c72-4d2a-8565-ff24bd576a89"));
+            Assert.That((int) referenceSource[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) referenceSource[PropertyNames.ClassKind], Is.EqualTo("ReferenceSource"));
 
             Assert.IsFalse((bool) referenceSource[PropertyNames.IsDeprecated]);
-            Assert.AreEqual("Test Reference Source", (string) referenceSource[PropertyNames.Name]);
-            Assert.AreEqual("TestReferenceSource", (string) referenceSource[PropertyNames.ShortName]);
+            Assert.That((string) referenceSource[PropertyNames.Name], Is.EqualTo("Test Reference Source"));
+            Assert.That((string) referenceSource[PropertyNames.ShortName], Is.EqualTo("TestReferenceSource"));
 
-            Assert.IsNull((string) referenceSource[PropertyNames.VersionIdentifier]);
-            Assert.IsNull((string) referenceSource[PropertyNames.VersionDate]);
-            Assert.AreEqual("", (string)referenceSource[PropertyNames.Author]);            
-            Assert.AreEqual(1999, (int) referenceSource[PropertyNames.PublicationYear]);
-            Assert.IsNull((string) referenceSource[PropertyNames.Publisher]);
-            Assert.IsNull((string) referenceSource[PropertyNames.PublishedIn]);
-            Assert.AreEqual("", (string)referenceSource[PropertyNames.Language]);
+            Assert.That((string) referenceSource[PropertyNames.VersionIdentifier], Is.Null);
+            Assert.That((string) referenceSource[PropertyNames.VersionDate], Is.Null);
+            Assert.That((string)referenceSource[PropertyNames.Author], Is.EqualTo(""));            
+            Assert.That((int) referenceSource[PropertyNames.PublicationYear], Is.EqualTo(1999));
+            Assert.That((string) referenceSource[PropertyNames.Publisher], Is.Null);
+            Assert.That((string) referenceSource[PropertyNames.PublishedIn], Is.Null);
+            Assert.That((string)referenceSource[PropertyNames.Language], Is.EqualTo(""));
             
             var expectedCategories = new string[] {};
             var categoriesArray = (JArray) referenceSource[PropertyNames.Category];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ReferencerRule/ReferencerRuleTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/ReferencerRule/ReferencerRuleTestFixture.cs
@@ -86,20 +86,20 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken referencerRule)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(13, referencerRule.Children().Count());
+            Assert.That(referencerRule.Children().Count(), Is.EqualTo(13));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("e7e4eec5-ad39-40a0-9548-9c40d8e6df1b", (string) referencerRule["iid"]);
-            Assert.AreEqual(1, (int) referencerRule["revisionNumber"]);
-            Assert.AreEqual("ReferencerRule", (string) referencerRule["classKind"]);
+            Assert.That((string) referencerRule["iid"], Is.EqualTo("e7e4eec5-ad39-40a0-9548-9c40d8e6df1b"));
+            Assert.That((int) referencerRule["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) referencerRule["classKind"], Is.EqualTo("ReferencerRule"));
 
             Assert.IsFalse((bool) referencerRule["isDeprecated"]);
-            Assert.AreEqual("TestReferencerRule", (string) referencerRule["name"]);
-            Assert.AreEqual("Test Referencer Rule", (string) referencerRule["shortName"]);
+            Assert.That((string) referencerRule["name"], Is.EqualTo("TestReferencerRule"));
+            Assert.That((string) referencerRule["shortName"], Is.EqualTo("Test Referencer Rule"));
 
-            Assert.AreEqual("cf059b19-235c-48be-87a3-9a8942c8e3e0", (string) referencerRule["referencingCategory"]);
-            Assert.AreEqual(0, (int) referencerRule["minReferenced"]);
-            Assert.AreEqual(-1, (int) referencerRule["maxReferenced"]);
+            Assert.That((string) referencerRule["referencingCategory"], Is.EqualTo("cf059b19-235c-48be-87a3-9a8942c8e3e0"));
+            Assert.That((int) referencerRule["minReferenced"], Is.EqualTo(0));
+            Assert.That((int) referencerRule["maxReferenced"], Is.EqualTo(-1));
 
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) referencerRule["alias"];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SimpleQuantityKind/SimpleQuantityKindTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SimpleQuantityKind/SimpleQuantityKindTestFixture.cs
@@ -86,21 +86,20 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken simpleQuantityKind)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(14, simpleQuantityKind.Children().Count());
+            Assert.That(simpleQuantityKind.Children().Count(), Is.EqualTo(14));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("4f9f3d9b-f3de-4ef5-b6cb-2e22199fab0d", (string) simpleQuantityKind[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) simpleQuantityKind[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SimpleQuantityKind", (string) simpleQuantityKind[PropertyNames.ClassKind]);
+            Assert.That((string) simpleQuantityKind[PropertyNames.Iid], Is.EqualTo("4f9f3d9b-f3de-4ef5-b6cb-2e22199fab0d"));
+            Assert.That((int) simpleQuantityKind[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) simpleQuantityKind[PropertyNames.ClassKind], Is.EqualTo("SimpleQuantityKind"));
 
             Assert.IsFalse((bool) simpleQuantityKind[PropertyNames.IsDeprecated]);
-            Assert.AreEqual("Test Simple QuantityKind", (string) simpleQuantityKind[PropertyNames.Name]);
-            Assert.AreEqual("TestSimpleQuantityKind", (string) simpleQuantityKind[PropertyNames.ShortName]);
+            Assert.That((string) simpleQuantityKind[PropertyNames.Name], Is.EqualTo("Test Simple QuantityKind"));
+            Assert.That((string) simpleQuantityKind[PropertyNames.ShortName], Is.EqualTo("TestSimpleQuantityKind"));
 
-            Assert.AreEqual("testsymbol", (string) simpleQuantityKind[PropertyNames.Symbol]);
-            Assert.AreEqual("53e82aeb-c42c-475c-b6bf-a102af883471", (string) simpleQuantityKind[PropertyNames.DefaultScale]);
-            Assert.AreEqual("testQuantityDimensionSymbol",
-                (string) simpleQuantityKind[PropertyNames.QuantityDimensionSymbol]);
+            Assert.That((string) simpleQuantityKind[PropertyNames.Symbol], Is.EqualTo("testsymbol"));
+            Assert.That((string) simpleQuantityKind[PropertyNames.DefaultScale], Is.EqualTo("53e82aeb-c42c-475c-b6bf-a102af883471"));
+            Assert.That((string) simpleQuantityKind[PropertyNames.QuantityDimensionSymbol], Is.EqualTo("testQuantityDimensionSymbol"));
 
             var expectedPossibleScales = new string[]
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SimpleUnit/SimpleUnitTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SimpleUnit/SimpleUnitTestFixture.cs
@@ -86,16 +86,16 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken simpleUnit)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(9, simpleUnit.Children().Count());
+            Assert.That(simpleUnit.Children().Count(), Is.EqualTo(9));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("56842970-3915-4369-8712-61cfd8273ef9", (string) simpleUnit["iid"]);
-            Assert.AreEqual(1, (int) simpleUnit["revisionNumber"]);
-            Assert.AreEqual("SimpleUnit", (string) simpleUnit["classKind"]);
+            Assert.That((string) simpleUnit["iid"], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
+            Assert.That((int) simpleUnit["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) simpleUnit["classKind"], Is.EqualTo("SimpleUnit"));
 
             Assert.IsFalse((bool) simpleUnit["isDeprecated"]);
-            Assert.AreEqual("test simple unit", (string) simpleUnit["name"]);
-            Assert.AreEqual("testsimpleunit", (string) simpleUnit["shortName"]);
+            Assert.That((string) simpleUnit["name"], Is.EqualTo("test simple unit"));
+            Assert.That((string) simpleUnit["shortName"], Is.EqualTo("testsimpleunit"));
 
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) simpleUnit["alias"];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SiteLogEntry/SiteLogEntryTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SiteLogEntry/SiteLogEntryTestFixture.cs
@@ -42,7 +42,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(siteLogEntryUri);
 
             // assert that there are 2 SiteLogEntry objects.
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             SiteLogEntryTestFixture.VerifyProperties(jArray);
         }
@@ -77,49 +77,49 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken siteLogEntry)
         {
             var siteLogEntryObject = siteLogEntry.Single(x => (string) x[PropertyNames.Iid] == "98ba7b8a-1a1b-4569-a17c-b1ff620246a5");
-            Assert.AreEqual("98ba7b8a-1a1b-4569-a17c-b1ff620246a5", (string) siteLogEntryObject[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) siteLogEntryObject[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SiteLogEntry", (string) siteLogEntryObject[PropertyNames.ClassKind]);
-            Assert.AreEqual("TRACE", (string) siteLogEntryObject[PropertyNames.Level]);
+            Assert.That((string) siteLogEntryObject[PropertyNames.Iid], Is.EqualTo("98ba7b8a-1a1b-4569-a17c-b1ff620246a5"));
+            Assert.That((int) siteLogEntryObject[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) siteLogEntryObject[PropertyNames.ClassKind], Is.EqualTo("SiteLogEntry"));
+            Assert.That((string) siteLogEntryObject[PropertyNames.Level], Is.EqualTo("TRACE"));
 
             // verify that there are no affectedItemIid for this SiteLogEntry
             var affectedItemIids = (JArray) siteLogEntryObject[PropertyNames.AffectedItemIid];
             IList<string> affectedItemIidsList = affectedItemIids.Select(x => (string) x).ToList();
             Assert.IsEmpty(affectedItemIidsList);
 
-            Assert.AreEqual("77791b12-4c2c-4499-93fa-869df3692d22", (string) siteLogEntryObject[PropertyNames.Author]);
+            Assert.That((string) siteLogEntryObject[PropertyNames.Author], Is.EqualTo("77791b12-4c2c-4499-93fa-869df3692d22"));
 
             // verify that there are no categories for this SiteLogEntry
             var categories = (JArray) siteLogEntryObject[PropertyNames.Category];
             IList<string> categoriesList = categories.Select(x => (string) x).ToList();
             Assert.IsEmpty(categoriesList);
 
-            Assert.AreEqual("TestLogEntry", (string) siteLogEntryObject[PropertyNames.Content]);
-            Assert.AreEqual("en-GB", (string) siteLogEntryObject[PropertyNames.LanguageCode]);
-            Assert.AreEqual("2016-10-19T11:15:32.186Z", (string) siteLogEntryObject[PropertyNames.CreatedOn]);
+            Assert.That((string) siteLogEntryObject[PropertyNames.Content], Is.EqualTo("TestLogEntry"));
+            Assert.That((string) siteLogEntryObject[PropertyNames.LanguageCode], Is.EqualTo("en-GB"));
+            Assert.That((string) siteLogEntryObject[PropertyNames.CreatedOn], Is.EqualTo("2016-10-19T11:15:32.186Z"));
 
             //Second logEntry
             siteLogEntryObject = siteLogEntry.Single(x => (string) x[PropertyNames.Iid] == "66220289-e6ee-43cb-8fcd-d8e59a3dbf97");
-            Assert.AreEqual("66220289-e6ee-43cb-8fcd-d8e59a3dbf97", (string) siteLogEntryObject[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) siteLogEntryObject[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SiteLogEntry", (string) siteLogEntryObject[PropertyNames.ClassKind]);
-            Assert.AreEqual("DEBUG", (string) siteLogEntryObject[PropertyNames.Level]);
+            Assert.That((string) siteLogEntryObject[PropertyNames.Iid], Is.EqualTo("66220289-e6ee-43cb-8fcd-d8e59a3dbf97"));
+            Assert.That((int) siteLogEntryObject[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) siteLogEntryObject[PropertyNames.ClassKind], Is.EqualTo("SiteLogEntry"));
+            Assert.That((string) siteLogEntryObject[PropertyNames.Level], Is.EqualTo("DEBUG"));
 
             // verify that there are no affectedItemIid for this SiteLogEntry
             affectedItemIids = (JArray) siteLogEntryObject[PropertyNames.AffectedItemIid];
             affectedItemIidsList = affectedItemIids.Select(x => (string) x).ToList();
             Assert.IsEmpty(affectedItemIidsList);
 
-            Assert.AreEqual("77791b12-4c2c-4499-93fa-869df3692d22", (string) siteLogEntryObject[PropertyNames.Author]);
+            Assert.That((string) siteLogEntryObject[PropertyNames.Author], Is.EqualTo("77791b12-4c2c-4499-93fa-869df3692d22"));
 
             // verify that there are no categories for this SiteLogEntry
             categories = (JArray) siteLogEntryObject[PropertyNames.Category];
             categoriesList = categories.Select(x => (string) x).ToList();
             Assert.IsEmpty(categoriesList);
 
-            Assert.AreEqual("TestLogEntry", (string) siteLogEntryObject[PropertyNames.Content]);
-            Assert.AreEqual("en-GB", (string) siteLogEntryObject[PropertyNames.LanguageCode]);
-            Assert.AreEqual("2016-10-19T11:15:42.384Z", (string) siteLogEntryObject[PropertyNames.CreatedOn]);
+            Assert.That((string) siteLogEntryObject[PropertyNames.Content], Is.EqualTo("TestLogEntry"));
+            Assert.That((string) siteLogEntryObject[PropertyNames.LanguageCode], Is.EqualTo("en-GB"));
+            Assert.That((string) siteLogEntryObject[PropertyNames.CreatedOn], Is.EqualTo("2016-10-19T11:15:42.384Z"));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SiteReferenceDataLibrary/SiteReferenceDataLibraryTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SiteReferenceDataLibrary/SiteReferenceDataLibraryTestFixture.cs
@@ -62,7 +62,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(siteReferenceDataLibraryUri);
 
             //check if there are only two objects
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             var siteDirectory = jArray.Single(x => (string) x["iid"] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
             SiteDirectoryTestFixture.VerifyProperties(siteDirectory);
@@ -96,7 +96,7 @@ namespace WebservicesIntegrationTests
                 }
             }
 
-            Assert.AreEqual(sumOfParameterTypeElements, setOfUniqueParameterTypeIids.Count);
+            Assert.That(setOfUniqueParameterTypeIids.Count, Is.EqualTo(sumOfParameterTypeElements));
         }
 
         [Test]
@@ -111,10 +111,10 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.PostDto(uri, postBody);
 
             //check if there are only two objects
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             var siteDirectory = jArray.Single(x => (string)x["iid"] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
-            Assert.AreEqual(2, (int)siteDirectory[PropertyNames.RevisionNumber]);
+            Assert.That((int)siteDirectory[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // get a specific SimpleUnit from the result by it's unique id
             var simpleUnit = jArray.Single(x => (string)x["iid"] == "56842970-3915-4369-8712-61cfd8273ef9");
@@ -131,16 +131,16 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken siteReferenceDataLibrary)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(22, siteReferenceDataLibrary.Children().Count());
+            Assert.That(siteReferenceDataLibrary.Children().Count(), Is.EqualTo(22));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("c454c687-ba3e-44c4-86bc-44544b2c7880", (string) siteReferenceDataLibrary["iid"]);
-            Assert.AreEqual(1, (int) siteReferenceDataLibrary["revisionNumber"]);
-            Assert.AreEqual("SiteReferenceDataLibrary", (string) siteReferenceDataLibrary["classKind"]);
+            Assert.That((string) siteReferenceDataLibrary["iid"], Is.EqualTo("c454c687-ba3e-44c4-86bc-44544b2c7880"));
+            Assert.That((int) siteReferenceDataLibrary["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) siteReferenceDataLibrary["classKind"], Is.EqualTo("SiteReferenceDataLibrary"));
 
             Assert.IsFalse((bool) siteReferenceDataLibrary["isDeprecated"]);
-            Assert.AreEqual("Test Reference Data Library", (string) siteReferenceDataLibrary["name"]);
-            Assert.AreEqual("TestRDL", (string) siteReferenceDataLibrary["shortName"]);
+            Assert.That((string) siteReferenceDataLibrary["name"], Is.EqualTo("Test Reference Data Library"));
+            Assert.That((string) siteReferenceDataLibrary["shortName"], Is.EqualTo("TestRDL"));
 
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) siteReferenceDataLibrary["alias"];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SpecializedQuantityKind/SpecializedQuantityKindTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/SpecializedQuantityKind/SpecializedQuantityKindTestFixture.cs
@@ -86,22 +86,21 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken specializedQuantityKind)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(15, specializedQuantityKind.Children().Count());
+            Assert.That(specializedQuantityKind.Children().Count(), Is.EqualTo(15));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("0a6dc59d-4292-43be-a247-b8d7074d5d52", (string) specializedQuantityKind[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) specializedQuantityKind[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SpecializedQuantityKind", (string) specializedQuantityKind[PropertyNames.ClassKind]);
+            Assert.That((string) specializedQuantityKind[PropertyNames.Iid], Is.EqualTo("0a6dc59d-4292-43be-a247-b8d7074d5d52"));
+            Assert.That((int) specializedQuantityKind[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) specializedQuantityKind[PropertyNames.ClassKind], Is.EqualTo("SpecializedQuantityKind"));
 
             Assert.IsFalse((bool) specializedQuantityKind[PropertyNames.IsDeprecated]);
-            Assert.AreEqual("Test Specialized QuantityKind", (string) specializedQuantityKind[PropertyNames.Name]);
-            Assert.AreEqual("TestSpecializedQuantityKind", (string) specializedQuantityKind[PropertyNames.ShortName]);
+            Assert.That((string) specializedQuantityKind[PropertyNames.Name], Is.EqualTo("Test Specialized QuantityKind"));
+            Assert.That((string) specializedQuantityKind[PropertyNames.ShortName], Is.EqualTo("TestSpecializedQuantityKind"));
 
-            Assert.AreEqual("testsymbol", (string) specializedQuantityKind[PropertyNames.Symbol]);
-            Assert.AreEqual("53e82aeb-c42c-475c-b6bf-a102af883471",
-                (string) specializedQuantityKind[PropertyNames.DefaultScale]);
-            Assert.AreEqual("", (string)specializedQuantityKind[PropertyNames.QuantityDimensionSymbol]);
-            Assert.AreEqual("4f9f3d9b-f3de-4ef5-b6cb-2e22199fab0d", (string) specializedQuantityKind[PropertyNames.General]);
+            Assert.That((string) specializedQuantityKind[PropertyNames.Symbol], Is.EqualTo("testsymbol"));
+            Assert.That((string) specializedQuantityKind[PropertyNames.DefaultScale], Is.EqualTo("53e82aeb-c42c-475c-b6bf-a102af883471"));
+            Assert.That((string)specializedQuantityKind[PropertyNames.QuantityDimensionSymbol], Is.EqualTo(""));
+            Assert.That((string) specializedQuantityKind[PropertyNames.General], Is.EqualTo("4f9f3d9b-f3de-4ef5-b6cb-2e22199fab0d"));
 
             var expectedPossibleScales = new string[]
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TelephoneNumber/TelephoneNumberTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TelephoneNumber/TelephoneNumberTestFixture.cs
@@ -42,7 +42,7 @@ namespace WebservicesIntegrationTests
             var jArray = this.WebClient.GetDto(telephoneNumbersUri);
 
             // assert that there are 2 TelephoneNumber objects.
-            Assert.AreEqual(2, jArray.Count);
+            Assert.That(jArray.Count, Is.EqualTo(2));
 
             VerifyProperties(jArray);
         }
@@ -122,17 +122,17 @@ namespace WebservicesIntegrationTests
             var siteDirectory = jArray.Single(x => (string) x[PropertyNames.Iid] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
 
             // verify that the amount of returned properties 
-            Assert.AreEqual(19, siteDirectory.Children().Count());
+            Assert.That(siteDirectory.Children().Count(), Is.EqualTo(19));
 
-            Assert.AreEqual("f13de6f8-b03a-46e7-a492-53b2f260f294", (string) siteDirectory[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) siteDirectory[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("SiteDirectory", (string) siteDirectory[PropertyNames.ClassKind]);
-            Assert.AreEqual("Test Site Directory", (string) siteDirectory[PropertyNames.Name]);
-            Assert.AreEqual("TEST-SiteDir", (string) siteDirectory[PropertyNames.ShortName]);
+            Assert.That((string) siteDirectory[PropertyNames.Iid], Is.EqualTo("f13de6f8-b03a-46e7-a492-53b2f260f294"));
+            Assert.That((int) siteDirectory[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) siteDirectory[PropertyNames.ClassKind], Is.EqualTo("SiteDirectory"));
+            Assert.That((string) siteDirectory[PropertyNames.Name], Is.EqualTo("Test Site Directory"));
+            Assert.That((string) siteDirectory[PropertyNames.ShortName], Is.EqualTo("TEST-SiteDir"));
 
-            Assert.AreEqual("ee3ae5ff-ac5e-4957-bab1-7698fba2a267", (string) siteDirectory[PropertyNames.DefaultParticipantRole]);
+            Assert.That((string) siteDirectory[PropertyNames.DefaultParticipantRole], Is.EqualTo("ee3ae5ff-ac5e-4957-bab1-7698fba2a267"));
 
-            Assert.AreEqual("2428f4d9-f26d-4112-9d56-1c940748df69", (string) siteDirectory[PropertyNames.DefaultPersonRole]);
+            Assert.That((string) siteDirectory[PropertyNames.DefaultPersonRole], Is.EqualTo("2428f4d9-f26d-4112-9d56-1c940748df69"));
 
             var expectedOrganizations = new string[] { "cd22fc45-d898-4fac-85fc-fbcb7d7b12a7" };
             var organizationArray = (JArray) siteDirectory[PropertyNames.Organization];
@@ -201,22 +201,22 @@ namespace WebservicesIntegrationTests
                 jArray.Single(x => (string) x[PropertyNames.Iid] == "77791b12-4c2c-4499-93fa-869df3692d22");
 
             // verify that the amount of returned properties 
-            Assert.AreEqual(18, person.Children().Count());
+            Assert.That(person.Children().Count(), Is.EqualTo(18));
 
-            Assert.AreEqual("77791b12-4c2c-4499-93fa-869df3692d22", (string) person[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) person[PropertyNames.RevisionNumber]);
+            Assert.That((string) person[PropertyNames.Iid], Is.EqualTo("77791b12-4c2c-4499-93fa-869df3692d22"));
+            Assert.That((int) person[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("John", (string) person[PropertyNames.GivenName]);
-            Assert.AreEqual("Doe", (string) person[PropertyNames.Surname]);
-            Assert.AreEqual("", (string) person[PropertyNames.OrganizationalUnit]);
-            Assert.AreEqual(null, (string) person[PropertyNames.Organization]);
-            Assert.AreEqual("0e92edde-fdff-41db-9b1d-f2e484f12535", (string) person[PropertyNames.DefaultDomain]);
+            Assert.That((string) person[PropertyNames.GivenName], Is.EqualTo("John"));
+            Assert.That((string) person[PropertyNames.Surname], Is.EqualTo("Doe"));
+            Assert.That((string) person[PropertyNames.OrganizationalUnit], Is.EqualTo(""));
+            Assert.That((string) person[PropertyNames.Organization], Is.EqualTo(null));
+            Assert.That((string) person[PropertyNames.DefaultDomain], Is.EqualTo("0e92edde-fdff-41db-9b1d-f2e484f12535"));
             Assert.IsTrue((bool) person[PropertyNames.IsActive]);
-            Assert.AreEqual("2428f4d9-f26d-4112-9d56-1c940748df69", (string) person[PropertyNames.Role]);
-            Assert.AreEqual(null, (string) person[PropertyNames.DefaultEmailAddress]);
-            Assert.AreEqual(null, (string) person[PropertyNames.DefaultTelephoneNumber]);
-            Assert.AreEqual("admin", (string) person[PropertyNames.ShortName]);
+            Assert.That((string) person[PropertyNames.Role], Is.EqualTo("2428f4d9-f26d-4112-9d56-1c940748df69"));
+            Assert.That((string) person[PropertyNames.DefaultEmailAddress], Is.EqualTo(null));
+            Assert.That((string) person[PropertyNames.DefaultTelephoneNumber], Is.EqualTo(null));
+            Assert.That((string) person[PropertyNames.ShortName], Is.EqualTo("admin"));
             Assert.IsFalse((bool) person[PropertyNames.IsDeprecated]);
 
             // verify that there are 2 emailAddresses for this person
@@ -252,10 +252,10 @@ namespace WebservicesIntegrationTests
                 jArray.Single(x => (string) x[PropertyNames.Iid] == "2e6559d6-2ccb-4627-a5f4-5906fb59e969");
 
             // assert that the properties are what is expected
-            Assert.AreEqual("2e6559d6-2ccb-4627-a5f4-5906fb59e969", (string) telephoneNumber[PropertyNames.Iid]);
-            Assert.AreEqual(2, (int) telephoneNumber[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("TelephoneNumber", (string) telephoneNumber[PropertyNames.ClassKind]);
-            Assert.AreEqual("+38-012-345-67-89", (string) telephoneNumber[PropertyNames.Value]);
+            Assert.That((string) telephoneNumber[PropertyNames.Iid], Is.EqualTo("2e6559d6-2ccb-4627-a5f4-5906fb59e969"));
+            Assert.That((int) telephoneNumber[PropertyNames.RevisionNumber], Is.EqualTo(2));
+            Assert.That((string) telephoneNumber[PropertyNames.ClassKind], Is.EqualTo("TelephoneNumber"));
+            Assert.That((string) telephoneNumber[PropertyNames.Value], Is.EqualTo("+38-012-345-67-89"));
 
             var expectedVcardTypes = new string[]
             {
@@ -278,10 +278,10 @@ namespace WebservicesIntegrationTests
         {
             var telephoneNumberObject = telephoneNumber.Single(x => (string) x[PropertyNames.Iid] == "7f85a641-1844-4064-b19d-c6a447543ab3");
 
-            Assert.AreEqual("7f85a641-1844-4064-b19d-c6a447543ab3", (string) telephoneNumberObject[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) telephoneNumberObject[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("TelephoneNumber", (string) telephoneNumberObject[PropertyNames.ClassKind]);
-            Assert.AreEqual("+38-044-444-44-44", (string) telephoneNumberObject[PropertyNames.Value]);
+            Assert.That((string) telephoneNumberObject[PropertyNames.Iid], Is.EqualTo("7f85a641-1844-4064-b19d-c6a447543ab3"));
+            Assert.That((int) telephoneNumberObject[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) telephoneNumberObject[PropertyNames.ClassKind], Is.EqualTo("TelephoneNumber"));
+            Assert.That((string) telephoneNumberObject[PropertyNames.Value], Is.EqualTo("+38-044-444-44-44"));
 
             var expectedVcardTypes = new string[]
             {
@@ -295,10 +295,10 @@ namespace WebservicesIntegrationTests
             telephoneNumberObject =
                 telephoneNumber.Single(x => (string) x[PropertyNames.Iid] == "0367167c-80cb-4f99-a24b-e713efd15436");
 
-            Assert.AreEqual("0367167c-80cb-4f99-a24b-e713efd15436", (string) telephoneNumberObject[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) telephoneNumberObject[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("TelephoneNumber", (string) telephoneNumberObject[PropertyNames.ClassKind]);
-            Assert.AreEqual("+38-066-666-66-66", (string) telephoneNumberObject[PropertyNames.Value]);
+            Assert.That((string) telephoneNumberObject[PropertyNames.Iid], Is.EqualTo("0367167c-80cb-4f99-a24b-e713efd15436"));
+            Assert.That((int) telephoneNumberObject[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) telephoneNumberObject[PropertyNames.ClassKind], Is.EqualTo("TelephoneNumber"));
+            Assert.That((string) telephoneNumberObject[PropertyNames.Value], Is.EqualTo("+38-066-666-66-66"));
 
             expectedVcardTypes = new string[]
             {

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Term/TermTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/Term/TermTestFixture.cs
@@ -86,16 +86,16 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken term)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(9, term.Children().Count());
+            Assert.That(term.Children().Count(), Is.EqualTo(9));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("18533006-1b9b-46c1-acc9-ae438ed4ebb2", (string) term["iid"]);
-            Assert.AreEqual(1, (int) term["revisionNumber"]);
-            Assert.AreEqual("Term", (string) term["classKind"]);
+            Assert.That((string) term["iid"], Is.EqualTo("18533006-1b9b-46c1-acc9-ae438ed4ebb2"));
+            Assert.That((int) term["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) term["classKind"], Is.EqualTo("Term"));
 
             Assert.IsFalse((bool) term["isDeprecated"]);
-            Assert.AreEqual("Test Term", (string) term["name"]);
-            Assert.AreEqual("TestTerm", (string) term["shortName"]);
+            Assert.That((string) term["name"], Is.EqualTo("Test Term"));
+            Assert.That((string) term["shortName"], Is.EqualTo("TestTerm"));
 
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) term["alias"];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TextParameterType/TextParameterTypeTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TextParameterType/TextParameterTypeTestFixture.cs
@@ -82,18 +82,18 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken textParameterType)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(11, textParameterType.Children().Count());
+            Assert.That(textParameterType.Children().Count(), Is.EqualTo(11));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("a21c15c4-3e1e-46b5-b109-5063dec1e254", (string) textParameterType[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) textParameterType[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("TextParameterType", (string) textParameterType[PropertyNames.ClassKind]);
+            Assert.That((string) textParameterType[PropertyNames.Iid], Is.EqualTo("a21c15c4-3e1e-46b5-b109-5063dec1e254"));
+            Assert.That((int) textParameterType[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) textParameterType[PropertyNames.ClassKind], Is.EqualTo("TextParameterType"));
 
             Assert.IsFalse((bool) textParameterType[PropertyNames.IsDeprecated]);
-            Assert.AreEqual("Test Text ParameterType", (string) textParameterType[PropertyNames.Name]);
-            Assert.AreEqual("TestTextParameterType", (string) textParameterType[PropertyNames.ShortName]);
+            Assert.That((string) textParameterType[PropertyNames.Name], Is.EqualTo("Test Text ParameterType"));
+            Assert.That((string) textParameterType[PropertyNames.ShortName], Is.EqualTo("TestTextParameterType"));
 
-            Assert.AreEqual("text", (string) textParameterType[PropertyNames.Symbol]);
+            Assert.That((string) textParameterType[PropertyNames.Symbol], Is.EqualTo("text"));
 
             var expectedCategories = new string[] {};
             var categoriesArray = (JArray) textParameterType[PropertyNames.Category];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TimeOfDayParameterType/TimeOfDayParameterTypeTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/TimeOfDayParameterType/TimeOfDayParameterTypeTestFixture.cs
@@ -86,18 +86,18 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken timeOfDayParameterType)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(11, timeOfDayParameterType.Children().Count());
+            Assert.That(timeOfDayParameterType.Children().Count(), Is.EqualTo(11));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("e4cfdb60-ed3a-455c-9a33-a3edc921637f", (string) timeOfDayParameterType[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) timeOfDayParameterType[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("TimeOfDayParameterType", (string) timeOfDayParameterType[PropertyNames.ClassKind]);
+            Assert.That((string) timeOfDayParameterType[PropertyNames.Iid], Is.EqualTo("e4cfdb60-ed3a-455c-9a33-a3edc921637f"));
+            Assert.That((int) timeOfDayParameterType[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) timeOfDayParameterType[PropertyNames.ClassKind], Is.EqualTo("TimeOfDayParameterType"));
 
             Assert.IsFalse((bool) timeOfDayParameterType[PropertyNames.IsDeprecated]);
-            Assert.AreEqual("Test Time Of Day ParameterType", (string) timeOfDayParameterType[PropertyNames.Name]);
-            Assert.AreEqual("TestTimeOfDayParameterType", (string) timeOfDayParameterType[PropertyNames.ShortName]);
+            Assert.That((string) timeOfDayParameterType[PropertyNames.Name], Is.EqualTo("Test Time Of Day ParameterType"));
+            Assert.That((string) timeOfDayParameterType[PropertyNames.ShortName], Is.EqualTo("TestTimeOfDayParameterType"));
 
-            Assert.AreEqual("timeofday", (string) timeOfDayParameterType[PropertyNames.Symbol]);
+            Assert.That((string) timeOfDayParameterType[PropertyNames.Symbol], Is.EqualTo("timeofday"));
 
             var expectedCategories = new string[] {};
             var categoriesArray = (JArray) timeOfDayParameterType[PropertyNames.Category];

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/UnitFactor/UnitFactorTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/UnitFactor/UnitFactorTestFixture.cs
@@ -97,13 +97,13 @@ namespace WebservicesIntegrationTests
             Assert.That(jArray.Count, Is.EqualTo(3));
 
             var siteDirectory = jArray.Single(x => (string) x[PropertyNames.Iid] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
-            Assert.AreEqual(2, (int) siteDirectory[PropertyNames.RevisionNumber]);
+            Assert.That((int) siteDirectory[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var unitFactor = jArray.Single(x => (string) x[PropertyNames.Iid] == "7d48eebe-c4e1-4081-ab63-7e4584563708");
-            Assert.AreEqual(2, (int) unitFactor[PropertyNames.RevisionNumber]);
+            Assert.That((int) unitFactor[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var derivedUnit = jArray.Single(x => (string) x[PropertyNames.Iid] == "c394eaa9-4832-4b2d-8d88-5e1b2c43732c");
-            Assert.AreEqual(2, (int) derivedUnit[PropertyNames.RevisionNumber]);
+            Assert.That((int) derivedUnit[PropertyNames.RevisionNumber], Is.EqualTo(2));
 
             var expectedUnitFactorArray = new List<OrderedItem> { new OrderedItem(2, "7d48eebe-c4e1-4081-ab63-7e4584563708"), new OrderedItem(23307173, "56c30a85-f648-4b31-87d2-153e8a74048b") };
             var unitFactorArray = JsonConvert.DeserializeObject<List<OrderedItem>>(derivedUnit[PropertyNames.UnitFactor].ToString());
@@ -117,16 +117,16 @@ namespace WebservicesIntegrationTests
             Assert.That(jArray.Count, Is.EqualTo(4));
 
             siteDirectory = jArray.Single(x => (string) x[PropertyNames.Iid] == "f13de6f8-b03a-46e7-a492-53b2f260f294");
-            Assert.AreEqual(3, (int) siteDirectory[PropertyNames.RevisionNumber]);
+            Assert.That((int) siteDirectory[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             unitFactor = jArray.Single(x => (string) x[PropertyNames.Iid] == "7d48eebe-c4e1-4081-ab63-7e4584563708");
-            Assert.AreEqual(3, (int) unitFactor[PropertyNames.RevisionNumber]);
+            Assert.That((int) unitFactor[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             var unitFactor2 = jArray.Single(x => (string) x[PropertyNames.Iid] == "56c30a85-f648-4b31-87d2-153e8a74048b");
-            Assert.AreEqual(3, (int) unitFactor2[PropertyNames.RevisionNumber]);
+            Assert.That((int) unitFactor2[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             derivedUnit = jArray.Single(x => (string) x[PropertyNames.Iid] == "c394eaa9-4832-4b2d-8d88-5e1b2c43732c");
-            Assert.AreEqual(3, (int) derivedUnit[PropertyNames.RevisionNumber]);
+            Assert.That((int) derivedUnit[PropertyNames.RevisionNumber], Is.EqualTo(3));
 
             expectedUnitFactorArray = new List<OrderedItem> { new OrderedItem(1, "56c30a85-f648-4b31-87d2-153e8a74048b"), new OrderedItem(3, "7d48eebe-c4e1-4081-ab63-7e4584563708") };
             unitFactorArray = JsonConvert.DeserializeObject<List<OrderedItem>>(derivedUnit[PropertyNames.UnitFactor].ToString());
@@ -143,14 +143,14 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken unitFactor)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(5, unitFactor.Children().Count());
+            Assert.That(unitFactor.Children().Count(), Is.EqualTo(5));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("56c30a85-f648-4b31-87d2-153e8a74048b", (string) unitFactor[PropertyNames.Iid]);
-            Assert.AreEqual(1, (int) unitFactor[PropertyNames.RevisionNumber]);
-            Assert.AreEqual("UnitFactor", (string) unitFactor[PropertyNames.ClassKind]);
-            Assert.AreEqual("56842970-3915-4369-8712-61cfd8273ef9", (string) unitFactor[PropertyNames.Unit]);
-            Assert.AreEqual("2", (string) unitFactor[PropertyNames.Exponent]);
+            Assert.That((string) unitFactor[PropertyNames.Iid], Is.EqualTo("56c30a85-f648-4b31-87d2-153e8a74048b"));
+            Assert.That((int) unitFactor[PropertyNames.RevisionNumber], Is.EqualTo(1));
+            Assert.That((string) unitFactor[PropertyNames.ClassKind], Is.EqualTo("UnitFactor"));
+            Assert.That((string) unitFactor[PropertyNames.Unit], Is.EqualTo("56842970-3915-4369-8712-61cfd8273ef9"));
+            Assert.That((string) unitFactor[PropertyNames.Exponent], Is.EqualTo("2"));
         }
     }
 }

--- a/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/UnitPrefix/UnitPrefixTestFixture.cs
+++ b/IntegrationTestSuite/WebservicesIntegrationTests/Tests/SiteDirectory/UnitPrefix/UnitPrefixTestFixture.cs
@@ -86,18 +86,18 @@ namespace WebservicesIntegrationTests
         public static void VerifyProperties(JToken unitPrefix)
         {
             // verify the amount of returned properties 
-            Assert.AreEqual(10, unitPrefix.Children().Count());
+            Assert.That(unitPrefix.Children().Count(), Is.EqualTo(10));
 
             // assert that the properties are what is expected
-            Assert.AreEqual("efa6380d-9508-4f3d-9b43-6ed33125b780", (string) unitPrefix["iid"]);
-            Assert.AreEqual(1, (int) unitPrefix["revisionNumber"]);
-            Assert.AreEqual("UnitPrefix", (string) unitPrefix["classKind"]);
+            Assert.That((string) unitPrefix["iid"], Is.EqualTo("efa6380d-9508-4f3d-9b43-6ed33125b780"));
+            Assert.That((int) unitPrefix["revisionNumber"], Is.EqualTo(1));
+            Assert.That((string) unitPrefix["classKind"], Is.EqualTo("UnitPrefix"));
 
             Assert.IsFalse((bool) unitPrefix["isDeprecated"]);
-            Assert.AreEqual("kilo", (string) unitPrefix["name"]);
-            Assert.AreEqual("k", (string) unitPrefix["shortName"]);
+            Assert.That((string) unitPrefix["name"], Is.EqualTo("kilo"));
+            Assert.That((string) unitPrefix["shortName"], Is.EqualTo("k"));
 
-            Assert.AreEqual("1e3", (string) unitPrefix["conversionFactor"]);
+            Assert.That((string) unitPrefix["conversionFactor"], Is.EqualTo("1e3"));
 
             var expectedAliases = new string[] {};
             var aliasesArray = (JArray) unitPrefix["alias"];


### PR DESCRIPTION
## Summary
- replace Assert.AreEqual usages with Assert.That(..., Is.EqualTo(...)) across the integration test fixtures
- migrate CollectionAssert.AreEqual calls to Assert.That for sequence comparisons
- convert Assert.IsNull checks to Assert.That(..., Is.Null) for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8e407bfd88326b61f94d878d31d53